### PR TITLE
Fix: tsconfig에 esModuleInterop: true로 설정

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -6,6 +6,8 @@
     "strict": true,
     "exactOptionalPropertyTypes": true,
     "skipLibCheck": true,
+    "esModuleInterop": true,
+
     "paths": {
       "types/*": ["./src/types"],
       "pages/*": ["./src/pages"],
@@ -13,8 +15,8 @@
       "hooks/*": ["./src/hooks"],
       "utils/*": ["./src/utils"],
       "assets/*": ["./src/assets"],
-      "constants/*": ["./src/constants"],
-    },
+      "constants/*": ["./src/constants"]
+    }
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #50 

# 🚀 작업 내용
`tsconfig` 에 `esModuleInterop: true`로 설정

# 💬 리뷰 중점사항
