### PR TITLE
feat: 메인 페이지 검색 기능 고도화

### DIFF
--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -8,6 +8,7 @@ const config: StorybookConfig = {
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',
     '@storybook/addon-viewport',
+    'storybook-addon-react-router-v6',
   ],
   framework: {
     name: '@storybook/react-webpack5',

--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -3,6 +3,7 @@ import type { Preview } from '@storybook/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { initialize, mswLoader } from 'msw-storybook-addon';
 import React from 'react';
+import { withRouter } from 'storybook-addon-react-router-v6';
 import { storybookHandlers } from '../src/mocks/storybookHandlers';
 import { decorateGlobalStyle } from './decorators';
 
@@ -33,6 +34,7 @@ const preview: Preview = {
         <Story />
       </QueryClientProvider>
     ),
+    withRouter,
   ],
   parameters: {
     viewport: {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -51,6 +51,7 @@
         "react-refresh": "^0.14.0",
         "react-refresh-typescript": "^2.0.9",
         "storybook": "^7.0.25",
+        "storybook-addon-react-router-v6": "^1.0.2",
         "stylelint": "^15.10.1",
         "stylelint-config-clean-order": "^5.0.1",
         "stylelint-config-styled-components": "^0.1.1",
@@ -17755,6 +17756,36 @@
         "url": "https://opencollective.com/storybook"
       }
     },
+    "node_modules/storybook-addon-react-router-v6": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/storybook-addon-react-router-v6/-/storybook-addon-react-router-v6-1.0.2.tgz",
+      "integrity": "sha512-38W+9D2sIrYAi+oRSbsLhR/umNoLVw2DWF84Jp4f/ZoB8Cg0Qtbvwk043oHqzNOpZrfgj0FaV006oaJBVpE8Kw==",
+      "dev": true,
+      "dependencies": {
+        "react-inspector": "^6.0.1"
+      },
+      "peerDependencies": {
+        "@storybook/blocks": "^7.0.0",
+        "@storybook/components": "^7.0.0",
+        "@storybook/core-events": "^7.0.0",
+        "@storybook/manager-api": "^7.0.0",
+        "@storybook/preview-api": "^7.0.0",
+        "@storybook/theming": "^7.0.0",
+        "@storybook/types": "^7.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-router": "^6.3.0",
+        "react-router-dom": "^6.3.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/stream-shift": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
@@ -32836,6 +32867,15 @@
       "dev": true,
       "requires": {
         "@storybook/cli": "7.0.25"
+      }
+    },
+    "storybook-addon-react-router-v6": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/storybook-addon-react-router-v6/-/storybook-addon-react-router-v6-1.0.2.tgz",
+      "integrity": "sha512-38W+9D2sIrYAi+oRSbsLhR/umNoLVw2DWF84Jp4f/ZoB8Cg0Qtbvwk043oHqzNOpZrfgj0FaV006oaJBVpE8Kw==",
+      "dev": true,
+      "requires": {
+        "react-inspector": "^6.0.1"
       }
     },
     "stream-shift": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,6 +54,7 @@
     "react-refresh": "^0.14.0",
     "react-refresh-typescript": "^2.0.9",
     "storybook": "^7.0.25",
+    "storybook-addon-react-router-v6": "^1.0.2",
     "stylelint": "^15.10.1",
     "stylelint-config-clean-order": "^5.0.1",
     "stylelint-config-styled-components": "^0.1.1",

--- a/frontend/src/apis/dictionary.ts
+++ b/frontend/src/apis/dictionary.ts
@@ -1,0 +1,9 @@
+const getNameSearch = (name: string) => {
+  return fetch(`/dictionary-plants?name=${name}`, { method: 'GET' });
+};
+
+const DictAPI = {
+  getNameSearch,
+};
+
+export default DictAPI;

--- a/frontend/src/apis/search.ts
+++ b/frontend/src/apis/search.ts
@@ -1,9 +1,0 @@
-const getResult = (name: string) => {
-  return fetch(`search?name=${name}`, { method: 'GET' });
-};
-
-const searchAPI = {
-  getResult,
-};
-
-export default searchAPI;

--- a/frontend/src/components/SearchBox/SearchBox.style.ts
+++ b/frontend/src/components/SearchBox/SearchBox.style.ts
@@ -39,7 +39,7 @@ export const ResultMessage = styled.p`
 `;
 
 export const ResultList = styled.div`
-  overflow: scroll;
+  overflow-x: none;
   width: 100%;
   max-height: 336px;
 `;

--- a/frontend/src/components/SearchBox/index.tsx
+++ b/frontend/src/components/SearchBox/index.tsx
@@ -47,6 +47,8 @@ const SearchBox = () => {
     search();
   };
 
+  const hasSearchResult = searchResults && searchName !== '';
+
   return (
     <Wrapper>
       <InputArea>
@@ -61,8 +63,7 @@ const SearchBox = () => {
           <BiRightArrowAlt size="32" color="#333333" />
         </EnterButton>
       </InputArea>
-      {searchResults &&
-        searchName !== '' &&
+      {hasSearchResult &&
         (searchResults.length ? (
           <ResultList>
             {searchResults.map(({ id, name, image }) => (

--- a/frontend/src/components/SearchBox/index.tsx
+++ b/frontend/src/components/SearchBox/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { BiSearch, BiRightArrowAlt } from 'react-icons/bi';
+import { useNavigate } from 'react-router-dom';
 import {
   InputArea,
   ResultItem,
@@ -18,6 +19,7 @@ import Dictionary from '../../queries/dictionaryPlants';
 const SearchBox = () => {
   const [searchName, setSearchName] = useState('');
   const queryName = useDebounce<string>(searchName, 200);
+  const navigate = useNavigate();
 
   const { data: searchResults } = Dictionary.useSearchName(queryName);
 
@@ -27,13 +29,22 @@ const SearchBox = () => {
     setSearchName(value);
   };
 
-  const searchOnEnter: React.ComponentProps<'input'>['onKeyDown'] = ({ key }) => {
-    if (key !== 'Enter') return;
-    console.log('searching...');
+  const search = () => {
+    if (!searchName || !searchResults) return;
+
+    const samePlant = searchResults.find(({ name }) => name === searchName);
+
+    if (!samePlant) {
+      navigate(`/dict?search=${searchName}`);
+      return;
+    }
+
+    navigate(`/dict/${samePlant.id}`);
   };
 
-  const searchOnClick = () => {
-    console.log('searching...');
+  const searchOnEnter: React.ComponentProps<'input'>['onKeyDown'] = ({ key }) => {
+    if (key !== 'Enter') return;
+    search();
   };
 
   return (
@@ -46,7 +57,7 @@ const SearchBox = () => {
           onChange={handleSearchNameChange}
           onKeyDown={searchOnEnter}
         />
-        <EnterButton type="button" onClick={searchOnClick}>
+        <EnterButton type="button" onClick={search}>
           <BiRightArrowAlt size="32" color="#333333" />
         </EnterButton>
       </InputArea>

--- a/frontend/src/components/SearchBox/index.tsx
+++ b/frontend/src/components/SearchBox/index.tsx
@@ -1,4 +1,3 @@
-import Dictionary from 'queries/dictionaryPlants';
 import { useState } from 'react';
 import { BiSearch, BiRightArrowAlt } from 'react-icons/bi';
 import {
@@ -13,6 +12,7 @@ import {
   ResultMessage,
 } from './SearchBox.style';
 import { MESSAGE } from 'constants/index';
+import Dictionary from '../../queries/dictionaryPlants';
 
 const SearchBox = () => {
   const [searchName, setSearchName] = useState('');

--- a/frontend/src/components/SearchBox/index.tsx
+++ b/frontend/src/components/SearchBox/index.tsx
@@ -1,5 +1,5 @@
-import type { DictNameSearchResult } from 'types/api/dictionary';
-import { useRef, useState } from 'react';
+import Dictionary from 'queries/dictionaryPlants';
+import { useState } from 'react';
 import { BiSearch, BiRightArrowAlt } from 'react-icons/bi';
 import {
   InputArea,
@@ -12,64 +12,44 @@ import {
   Input,
   ResultMessage,
 } from './SearchBox.style';
-import searchAPI from 'apis/search';
 import { MESSAGE } from 'constants/index';
 
 const SearchBox = () => {
   const [searchName, setSearchName] = useState('');
-  const [searchResults, setSearchResults] = useState<DictNameSearchResult[] | null>(null);
-  const timeoutId = useRef(0);
 
-  const changeSearch: React.ComponentProps<'input'>['onChange'] = ({ target: { value } }) => {
+  const { data: searchResults } = Dictionary.useSearchName(searchName);
+
+  const handleSearchNameChange: React.ChangeEventHandler<HTMLInputElement> = ({
+    target: { value },
+  }) => {
     setSearchName(value);
-
-    if (timeoutId.current) {
-      clearTimeout(timeoutId.current);
-    }
-
-    timeoutId.current = window.setTimeout(() => {
-      search(value);
-      timeoutId.current = 0;
-    }, 150);
   };
 
-  const enterSearch: React.ComponentProps<'input'>['onKeyDown'] = ({ key }) => {
+  const searchOnEnter: React.ComponentProps<'input'>['onKeyDown'] = ({ key }) => {
     if (key !== 'Enter') return;
-
-    search(searchName);
+    console.log('searching...');
   };
 
-  const clickSearch = () => {
-    search(searchName);
-  };
-
-  const search = async (name: string) => {
-    if (name === '') {
-      setSearchResults(null);
-      return;
-    }
-
-    try {
-      const response = await searchAPI.getResult(name);
-      if (!response.ok) throw new Error();
-
-      const { data: searchResults } = await response.json();
-      setSearchResults(searchResults);
-    } catch {
-      return;
-    }
+  const searchOnClick = () => {
+    console.log('searching...');
   };
 
   return (
     <Wrapper>
       <InputArea>
         <BiSearch size="32" color="#1bcc66" />
-        <Input type="text" value={searchName} onChange={changeSearch} onKeyDown={enterSearch} />
-        <EnterButton type="button" onClick={clickSearch}>
+        <Input
+          type="text"
+          value={searchName}
+          onChange={handleSearchNameChange}
+          onKeyDown={searchOnEnter}
+        />
+        <EnterButton type="button" onClick={searchOnClick}>
           <BiRightArrowAlt size="32" color="#333333" />
         </EnterButton>
       </InputArea>
       {searchResults &&
+        searchName !== '' &&
         (searchResults.length ? (
           <ResultList>
             {searchResults.map(({ id, name, image }) => (

--- a/frontend/src/components/SearchBox/index.tsx
+++ b/frontend/src/components/SearchBox/index.tsx
@@ -11,13 +11,15 @@ import {
   Input,
   ResultMessage,
 } from './SearchBox.style';
+import useDebounce from 'hooks/useDebounce';
 import { MESSAGE } from 'constants/index';
 import Dictionary from '../../queries/dictionaryPlants';
 
 const SearchBox = () => {
   const [searchName, setSearchName] = useState('');
+  const queryName = useDebounce<string>(searchName, 200);
 
-  const { data: searchResults } = Dictionary.useSearchName(searchName);
+  const { data: searchResults } = Dictionary.useSearchName(queryName);
 
   const handleSearchNameChange: React.ChangeEventHandler<HTMLInputElement> = ({
     target: { value },

--- a/frontend/src/hooks/useDebounce.ts
+++ b/frontend/src/hooks/useDebounce.ts
@@ -1,0 +1,22 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * 어떤 값에 debounce를 적용하여 debounce된 값을 보여줍니다.
+ *
+ * @param value debounce를 적용할 값
+ * @param delay debounce를 적용할 시간 (밀리초, ms)
+ * @returns debounce가 적용된 값
+ */
+const useDebounce = <T>(value: T, delay: number) => {
+  const [state, setState] = useState<T>(value);
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => setState(value), delay);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [value, delay]);
+
+  return state;
+};
+
+export default useDebounce;

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -18,7 +18,7 @@ export const makeHandler = (delay = 0, failRate = 0) => {
   validateParams(delay, failRate);
 
   return [
-    rest.get('/search', (req, res, ctx) => {
+    rest.get('/dictionary-plants', (req, res, ctx) => {
       if (Math.random() < failRate) {
         return res(ctx.delay(delay), ctx.status(500));
       }

--- a/frontend/src/mocks/storybookHandlers.ts
+++ b/frontend/src/mocks/storybookHandlers.ts
@@ -4,7 +4,7 @@ import DICTIONARY_PLANT_DATA from './data/dictionaryPlant';
 import SEARCH_DATA from './data/search';
 
 export const storybookHandlers = [
-  rest.get('/search', (req, res, ctx) => {
+  rest.get('/dictionary-plants', (req, res, ctx) => {
     const target = req.url.searchParams.get('name') ?? '';
     const searchResult = SEARCH_DATA.filter(({ name }) => name.includes(target));
 

--- a/frontend/src/pages/Main/Main.style.tsx
+++ b/frontend/src/pages/Main/Main.style.tsx
@@ -8,6 +8,7 @@ export const Wrapper = styled.div`
 
   width: 100%;
   height: 100%;
+  padding: 0 16px;
 `;
 
 export const LogoMessage = styled.p`

--- a/frontend/src/queries/dictionaryPlants.ts
+++ b/frontend/src/queries/dictionaryPlants.ts
@@ -1,0 +1,25 @@
+import type { DictNameSearchResponse, DictNameSearchResult } from 'types/api/dictionary';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import DictAPI from 'apis/dictionary';
+
+const useSearchName = (name: string) =>
+  useQuery<DictNameSearchResponse, Error, DictNameSearchResult[]>({
+    queryKey: ['search', name],
+
+    queryFn: async () => {
+      const response = await DictAPI.getNameSearch(name);
+      const data = await response.json();
+      return data;
+    },
+    select: ({ data }) => data,
+    placeholderData: keepPreviousData,
+
+    enabled: name.trim() !== '',
+    staleTime: Infinity,
+  });
+
+const Dictionary = {
+  useSearchName,
+};
+
+export default Dictionary;


### PR DESCRIPTION
# 🔥 연관 이슈

- close #89 
- close #64 

# 🚀 작업 내용

- api 명세 변경에 따른 msw 및 apis 수정

- useQuery를 이용한 api 통신 훅
- 검색창에 해당 훅 적용

- useDebounce 구현 및 적용

- 일치하는 이름을 찾아 사전 정보 또는 유사 목록으로 이동하는 콜백

- 스토리북 라우터 설정

# 💬 리뷰 중점사항

fetcher는 apis 폴더에,
서버 상태 관리는 queries 폴더에 넣는 방향으로 구현하였습니다.

컴포넌트에서는 본인이 필요한 훅을 queries에서 불러오기만 하면 되기 때문에 간편해요
fetcher와 react query 로직을 분리해 놓았기 때문에 나중에 axios로 갈아탄다면 고치기 유리해요

파일명은 나중에 의논해보면 좋을 것 같아요

이런 방식의 분할이 어떨지 여러분의 의견이 궁금해요 👍 