### PR TITLE
feat:  사전 식물 검색 결과 페이지

### DIFF
--- a/frontend/src/components/DateInput/DateInput.style.ts
+++ b/frontend/src/components/DateInput/DateInput.style.ts
@@ -8,7 +8,7 @@ export const Wrapper = styled.div`
 `;
 
 export const DateValue = styled.label<{
-  placeholder?: boolean;
+  $placeholder?: boolean;
 }>`
   position: absolute;
   left: 50%;
@@ -17,7 +17,7 @@ export const DateValue = styled.label<{
   display: inline-block;
 
   font: 500 1.8rem/2.2rem 'NanumSquareRound';
-  color: ${({ placeholder, theme }) => (placeholder ? theme.color.gray : 'black')};
+  color: ${({ $placeholder, theme }) => ($placeholder ? theme.color.gray : 'black')};
 `;
 
 export const Date = styled.input.attrs({ type: 'date' })`

--- a/frontend/src/components/DateInput/index.tsx
+++ b/frontend/src/components/DateInput/index.tsx
@@ -24,7 +24,7 @@ const DateInput = ({ value, onChange, placeholder = '날짜를 입력해 주세�
 
   return (
     <Wrapper>
-      <DateValue htmlFor={dateId} placeholder={value === ''}>
+      <DateValue htmlFor={dateId} $placeholder={value === ''}>
         {value ? convertDateKorYear(value) : placeholder}
       </DateValue>
       <Date id={dateId} type="date" onChange={changeHandler} />

--- a/frontend/src/components/FormInput/FormInput.stories.tsx
+++ b/frontend/src/components/FormInput/FormInput.stories.tsx
@@ -3,8 +3,20 @@ import useNumberInput from 'hooks/useNumberInput';
 import { NUMBER } from 'constants/index';
 import FormInput from '.';
 
+/**
+ * 테두리는 가시성을 위해 추가하였습니다.
+ *
+ * 실제 컴포넌트에는 없어요!
+ */
 const meta: Meta<typeof FormInput> = {
   component: FormInput,
+  decorators: [
+    (Story) => (
+      <div style={{ border: '1px solid black' }}>
+        <Story />
+      </div>
+    ),
+  ],
 };
 
 export default meta;
@@ -12,24 +24,23 @@ export default meta;
 type Story = StoryObj<typeof FormInput>;
 
 export const Default: Story = {
-  render: () => {
-    const changeCallback: React.ChangeEventHandler<HTMLInputElement> = (e) =>
-      console.log(e.target.value);
-
-    return <FormInput onChange={changeCallback} />;
+  argTypes: {
+    onChange: { action: '값이 바뀌었어요' },
   },
 };
 
 export const NumberInput: Story = {
-  render: () => {
+  argTypes: {
+    nextCallback: { action: '화살표 버튼을 눌렀어요' },
+  },
+
+  render: ({ nextCallback = () => console.log('clicked') }) => {
     const { MAX_CYCLE_DATE, MIN_CYCLE_DATE } = NUMBER;
 
     const { numberValue, changeCallback, keyDownHandler } = useNumberInput({
       maxRange: MAX_CYCLE_DATE,
       minRange: MIN_CYCLE_DATE,
     });
-
-    const nextCallback = () => console.log('clicked');
 
     return (
       <FormInput

--- a/frontend/src/components/FormInput/FormInput.style.ts
+++ b/frontend/src/components/FormInput/FormInput.style.ts
@@ -23,7 +23,7 @@ export const Input = styled.input`
   }
 `;
 
-export const IconArea = styled.div`
+export const Button = styled.button`
   position: absolute;
   right: 8px;
 

--- a/frontend/src/components/FormInput/index.tsx
+++ b/frontend/src/components/FormInput/index.tsx
@@ -1,6 +1,6 @@
 import { InputHTMLAttributes } from 'react';
 import { GrLinkNext } from 'react-icons/gr';
-import { IconArea, Input, Wrapper } from './FormInput.style';
+import { Button, Input, Wrapper } from './FormInput.style';
 
 interface FormInputProps extends InputHTMLAttributes<HTMLInputElement> {
   nextCallback?: () => void;
@@ -12,7 +12,7 @@ const FormInput = (props: FormInputProps) => {
   return (
     <Wrapper>
       <Input type="text" {...inputProps} />
-      <IconArea>{nextCallback && <GrLinkNext size={16} onClick={nextCallback} />}</IconArea>
+      <Button>{nextCallback && <GrLinkNext size={16} onClick={nextCallback} />}</Button>
     </Wrapper>
   );
 };

--- a/frontend/src/components/InlineRadio/ingredients/Option.style.ts
+++ b/frontend/src/components/InlineRadio/ingredients/Option.style.ts
@@ -11,6 +11,7 @@ export const HiddenRadio = styled.input`
 `;
 
 export const Label = styled.label`
+  cursor: pointer;
   display: inline-block;
   padding: 3px 13px;
 

--- a/frontend/src/components/SearchBox/SearchBox.stories.tsx
+++ b/frontend/src/components/SearchBox/SearchBox.stories.tsx
@@ -3,6 +3,12 @@ import SearchBox from '.';
 
 const meta: Meta<typeof SearchBox> = {
   component: SearchBox,
+
+  argTypes: {
+    onEnter: { action: '엔터 키를 눌렀습니다.' },
+    onNextClick: { action: '화살표 버튼을 눌렀습니다.' },
+    onResultClick: { action: '검색된 식물 중 하나를 눌렀습니다.' },
+  },
 };
 
 export default meta;

--- a/frontend/src/components/SearchResultItem/SearchResultItem.stories.tsx
+++ b/frontend/src/components/SearchResultItem/SearchResultItem.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import SearchResultItem from '.';
+
+const meta: Meta<typeof SearchResultItem> = {
+  component: SearchResultItem,
+  args: {
+    id: 1,
+    name: '겨울',
+    imageUrl: 'https://images.unsplash.com/photo-1520084848344-f4c32b3f7b51',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SearchResultItem>;
+
+export const Default: Story = {};

--- a/frontend/src/components/SearchResultItem/SearchResultItem.style.ts
+++ b/frontend/src/components/SearchResultItem/SearchResultItem.style.ts
@@ -1,0 +1,21 @@
+import { styled } from 'styled-components';
+
+export const Wrapper = styled.div`
+  display: flex;
+  column-gap: 20px;
+  align-items: center;
+
+  width: 100%;
+  height: 70px;
+  padding: 10px;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.color.grayLight};
+  }
+`;
+
+export const Name = styled.p`
+  display: flex;
+  align-items: center;
+  font: ${({ theme }) => theme.font.input};
+`;

--- a/frontend/src/components/SearchResultItem/index.tsx
+++ b/frontend/src/components/SearchResultItem/index.tsx
@@ -1,0 +1,24 @@
+import { Link } from 'react-router-dom';
+import Image from 'components/Image';
+import { Wrapper, Name } from './SearchResultItem.style';
+
+interface SearchResultItemProps {
+  id: number;
+  name: string;
+  imageUrl: string;
+}
+
+const SearchResultItem = (props: SearchResultItemProps) => {
+  const { id, name, imageUrl } = props;
+
+  return (
+    <Link to={`/dict/${id}`}>
+      <Wrapper>
+        <Image type="circle" size="55px" alt={name} src={imageUrl} />
+        <Name>{name}</Name>
+      </Wrapper>
+    </Link>
+  );
+};
+
+export default SearchResultItem;

--- a/frontend/src/components/SearchResults/SearchResults.stories.tsx
+++ b/frontend/src/components/SearchResults/SearchResults.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import SearchResults from '.';
+
+const meta: Meta<typeof SearchResults> = {
+  component: SearchResults,
+  args: {
+    plantName: '아',
+  },
+  argTypes: {
+    plantName: {
+      type: 'string',
+      description: '검색할 식물 이름',
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SearchResults>;
+
+export const Default: Story = {};

--- a/frontend/src/components/SearchResults/SearchResults.style.ts
+++ b/frontend/src/components/SearchResults/SearchResults.style.ts
@@ -1,0 +1,19 @@
+import { styled } from 'styled-components';
+
+export const ResultArea = styled.div`
+  display: flex;
+  flex-direction: column;
+  row-gap: 10px;
+  padding: 10px;
+`;
+
+export const Title = styled.p`
+  font: ${({ theme }) => theme.font.dictTitle};
+`;
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  row-gap: 30px;
+  padding: 10px;
+`;

--- a/frontend/src/components/SearchResults/index.tsx
+++ b/frontend/src/components/SearchResults/index.tsx
@@ -1,0 +1,46 @@
+import SearchResultItem from 'components/SearchResultItem';
+import { Title, ResultArea, Wrapper } from './SearchResults.style';
+import Dictionary from '../../queries/dictionaryPlants';
+
+interface SearchResultsProps {
+  plantName: string;
+}
+
+const SearchResults = (props: SearchResultsProps) => {
+  const { plantName } = props;
+  const { data } = Dictionary.useSearchName(plantName);
+
+  const samePlant = data?.find(({ name }) => name === plantName);
+  const similarPlants = data?.filter(({ name }) => name !== plantName);
+
+  const hasSimilarPlant = similarPlants && similarPlants.length > 0;
+
+  if (!data || (!samePlant && !hasSimilarPlant)) {
+    return (
+      <Wrapper>
+        <Title>&quot;{plantName}&quot; 검색 결과가 없어요 😭</Title>
+      </Wrapper>
+    );
+  }
+
+  return (
+    <Wrapper>
+      {samePlant && (
+        <ResultArea>
+          <Title>완전 똑같은 식물!!</Title>
+          <SearchResultItem id={samePlant.id} imageUrl={samePlant.image} name={samePlant.name} />
+        </ResultArea>
+      )}
+      {!!similarPlants?.length && (
+        <ResultArea>
+          <Title>비슷한 이름을 가진 식물</Title>
+          {similarPlants.map(({ id, name, image }) => (
+            <SearchResultItem key={id} id={id} name={name} imageUrl={image} />
+          ))}
+        </ResultArea>
+      )}
+    </Wrapper>
+  );
+};
+
+export default SearchResults;

--- a/frontend/src/components/Select/Select.style.ts
+++ b/frontend/src/components/Select/Select.style.ts
@@ -1,11 +1,11 @@
 import { styled } from 'styled-components';
 
 interface IconAreaProps {
-  rotate: boolean;
+  $rotate: boolean;
 }
 
 interface SelectedValueProps {
-  placeholder?: boolean;
+  $placeholder?: boolean;
 }
 
 export const Wrapper = styled.div`
@@ -29,7 +29,7 @@ export const SelectedValue = styled.p<SelectedValueProps>`
   width: 100%;
   height: 32px;
 
-  color: ${({ placeholder, theme }) => (placeholder ? theme.color.gray : 'black')};
+  color: ${({ $placeholder, theme }) => ($placeholder ? theme.color.gray : 'black')};
 
   &:hover {
     background: #0000000c;
@@ -39,7 +39,7 @@ export const SelectedValue = styled.p<SelectedValueProps>`
 export const IconArea = styled.div<IconAreaProps>`
   position: absolute;
   right: 8px;
-  transform: ${(props) => props.rotate && 'rotate(0.5turn)'};
+  transform: ${(props) => props.$rotate && 'rotate(0.5turn)'};
 
   display: flex;
   align-items: center;

--- a/frontend/src/components/Select/index.tsx
+++ b/frontend/src/components/Select/index.tsx
@@ -27,10 +27,10 @@ const Select = ({ value, options, onChange, placeholder }: SelectProps) => {
 
   return (
     <Wrapper>
-      <SelectedValue onClick={toggle} placeholder={value === ''}>
+      <SelectedValue onClick={toggle} $placeholder={value === ''}>
         {value || placeholder}
       </SelectedValue>
-      <IconArea rotate={isOpen}>
+      <IconArea $rotate={isOpen}>
         <TiArrowSortedDown size={18} />
       </IconArea>
       {isOpen && (

--- a/frontend/src/hooks/useDictrionaryNavigate.ts
+++ b/frontend/src/hooks/useDictrionaryNavigate.ts
@@ -1,0 +1,31 @@
+import type { DictNameSearchResult } from 'types/api/dictionary';
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const useDictionaryNavigate = () => {
+  const navigate = useNavigate();
+
+  const goToDictDetailPage = useCallback((plantId: number) => {
+    navigate(`/dict/${plantId}`);
+  }, []);
+
+  const goToProperDictPage = useCallback(
+    (searchName: string, searchResults?: DictNameSearchResult[]) => {
+      if (!searchName || !searchResults) return;
+
+      const samePlant = searchResults.find(({ name }) => name === searchName);
+
+      if (!samePlant) {
+        navigate(`/dict?search=${searchName}`);
+        return;
+      }
+
+      goToDictDetailPage(samePlant.id);
+    },
+    []
+  );
+
+  return { goToDictDetailPage, goToProperDictPage };
+};
+
+export default useDictionaryNavigate;

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -1,5 +1,6 @@
 import type { NewPetPlantRequest } from 'types/api/petPlant';
 import { rest } from 'msw';
+import { BASE_URL } from 'constants/index';
 import DICTIONARY_PLANT_DATA from './data/dictionaryPlant';
 import SEARCH_DATA from './data/search';
 import PetPlant from './storage/PetPlant';
@@ -14,14 +15,14 @@ const validateParams = (delay: number, failRate: number) => {
   }
 };
 
-const DICT = '/dictionary-plants';
-const PET = '/pet-plants';
+const DICT = `${BASE_URL}/dictionary-plants`;
+const PET = `${BASE_URL}/pet-plants`;
 
 export const makeHandler = (delay = 0, failRate = 0) => {
   validateParams(delay, failRate);
 
   return [
-    rest.get('/dictionary-plants', (req, res, ctx) => {
+    rest.get(DICT, (req, res, ctx) => {
       if (Math.random() < failRate) {
         return res(ctx.delay(delay), ctx.status(500));
       }

--- a/frontend/src/mocks/storybookHandlers.ts
+++ b/frontend/src/mocks/storybookHandlers.ts
@@ -1,19 +1,22 @@
 import type { NewPetPlantRequest } from 'types/api/petPlant';
 import { rest } from 'msw';
+import { BASE_URL } from 'constants/index';
 import DICTIONARY_PLANT_DATA from './data/dictionaryPlant';
 import SEARCH_DATA from './data/search';
 
 export const storybookHandlers = [
-  rest.get('/dictionary-plants', (req, res, ctx) => {
+  rest.get(`${BASE_URL}/dictionary-plants`, (req, res, ctx) => {
     const target = req.url.searchParams.get('name') ?? '';
     const searchResult = SEARCH_DATA.filter(({ name }) => name.includes(target));
 
     return res(ctx.status(200), ctx.json({ data: searchResult }));
   }),
 
-  rest.get('/dictionary-plants/:id', (req, res, ctx) => {
+  rest.get(`${BASE_URL}/dictionary-plants/:id`, (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(DICTIONARY_PLANT_DATA));
   }),
 
-  rest.post<NewPetPlantRequest>('/pet-plants', async (req, res, ctx) => res(ctx.status(201))),
+  rest.post<NewPetPlantRequest>(`${BASE_URL}/pet-plants`, async (req, res, ctx) =>
+    res(ctx.status(201))
+  ),
 ];

--- a/frontend/src/pages/DictionaryDetail/index.tsx
+++ b/frontend/src/pages/DictionaryDetail/index.tsx
@@ -20,6 +20,7 @@ import {
 } from './DictionaryDetail.style';
 import useDictionaryPlants from 'hooks/useDictionaryPlants';
 import useInvalidIdParams from 'hooks/useInvalidIdParams';
+import parseTemperature from 'utils/parseTemperature';
 import { MANAGE_LEVEL_COLOR } from 'constants/index';
 
 const DictionaryDetail = () => {
@@ -51,7 +52,7 @@ const DictionaryDetail = () => {
     <DictInfo.Content key={idx}>{position}</DictInfo.Content>
   ));
 
-  console.log(MANAGE_LEVEL_COLOR[manageLevel]);
+  const { type: tempType, temperature: minTemp } = parseTemperature(minimumTemp);
 
   return (
     <Wrapper>
@@ -112,7 +113,7 @@ const DictionaryDetail = () => {
             <PropBox>
               <BsThermometerSnow color="#1BCC66" />
               <span>
-                적어도 <Accent>{`"${minimumTemp}"`}</Accent> 이상에서 키워야 해요!🥶
+                적어도 <Accent>{`"${minTemp} ${tempType}"`}</Accent> 에서 키워야 해요!🥶
               </span>
             </PropBox>
           )}
@@ -121,7 +122,7 @@ const DictionaryDetail = () => {
             <PropBox>
               <GiFragrance color="#1BCC66" />
               <span>
-                냄새는 <Accent>{`"${smell}"`}</Accent>이에요!🪄
+                냄새는 <Accent>{`"${smell}"`}</Accent>이에요🤧
               </span>
             </PropBox>
           )}

--- a/frontend/src/pages/DictionarySearch/DictionarySearch.style.ts
+++ b/frontend/src/pages/DictionarySearch/DictionarySearch.style.ts
@@ -1,0 +1,8 @@
+import { styled } from 'styled-components';
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  row-gap: 30px;
+  padding: 30px 10px;
+`;

--- a/frontend/src/pages/DictionarySearch/index.tsx
+++ b/frontend/src/pages/DictionarySearch/index.tsx
@@ -1,0 +1,25 @@
+import { useSearchParams } from 'react-router-dom';
+import SearchBox from 'components/SearchBox';
+import SearchResults from 'components/SearchResults';
+import { Wrapper } from './DictionarySearch.style';
+import useDictionaryNavigate from 'hooks/useDictrionaryNavigate';
+
+const DictionarySearch = () => {
+  const [params] = useSearchParams();
+  const search = params.get('search') ?? '';
+
+  const { goToProperDictPage, goToDictDetailPage } = useDictionaryNavigate();
+
+  return (
+    <Wrapper>
+      <SearchBox
+        onEnter={goToProperDictPage}
+        onNextClick={goToProperDictPage}
+        onResultClick={goToDictDetailPage}
+      />
+      <SearchResults plantName={search} />
+    </Wrapper>
+  );
+};
+
+export default DictionarySearch;

--- a/frontend/src/pages/Main/index.tsx
+++ b/frontend/src/pages/Main/index.tsx
@@ -1,3 +1,4 @@
+import type { DictNameSearchResult } from 'types/api/dictionary';
 import { CgEnter } from 'react-icons/cg';
 import { useNavigate } from 'react-router-dom';
 import SearchBox from 'components/SearchBox';
@@ -20,6 +21,23 @@ const Main = () => {
     navigate(URL_PATH.PET_REGISTER_SEARCH);
   };
 
+  const goToDictDetailPage = (plantId: number) => {
+    navigate(`/dict/${plantId}`);
+  };
+
+  const search = (searchName: string, searchResults?: DictNameSearchResult[]) => {
+    if (!searchName || !searchResults) return;
+
+    const samePlant = searchResults.find(({ name }) => name === searchName);
+
+    if (!samePlant) {
+      navigate(`/dict?search=${searchName}`);
+      return;
+    }
+
+    goToDictDetailPage(samePlant.id);
+  };
+
   return (
     <Wrapper>
       <ButtonArea>
@@ -32,7 +50,7 @@ const Main = () => {
       <Logo src={logo} alt="logo" />
       <SearchMessage>피움에 등록된 식물을 검색해 보세요!</SearchMessage>
       <SearchBoxArea>
-        <SearchBox />
+        <SearchBox onEnter={search} onNextClick={search} onResultClick={goToDictDetailPage} />
       </SearchBoxArea>
     </Wrapper>
   );

--- a/frontend/src/pages/Main/index.tsx
+++ b/frontend/src/pages/Main/index.tsx
@@ -1,4 +1,3 @@
-import type { DictNameSearchResult } from 'types/api/dictionary';
 import { CgEnter } from 'react-icons/cg';
 import { useNavigate } from 'react-router-dom';
 import SearchBox from 'components/SearchBox';
@@ -11,6 +10,7 @@ import {
   StartButton,
   Wrapper,
 } from './Main.style';
+import useDictionaryNavigate from 'hooks/useDictrionaryNavigate';
 import { URL_PATH } from 'constants/index';
 import logo from 'assets/logo.svg';
 
@@ -21,22 +21,7 @@ const Main = () => {
     navigate(URL_PATH.PET_REGISTER_SEARCH);
   };
 
-  const goToDictDetailPage = (plantId: number) => {
-    navigate(`/dict/${plantId}`);
-  };
-
-  const search = (searchName: string, searchResults?: DictNameSearchResult[]) => {
-    if (!searchName || !searchResults) return;
-
-    const samePlant = searchResults.find(({ name }) => name === searchName);
-
-    if (!samePlant) {
-      navigate(`/dict?search=${searchName}`);
-      return;
-    }
-
-    goToDictDetailPage(samePlant.id);
-  };
+  const { goToProperDictPage, goToDictDetailPage } = useDictionaryNavigate();
 
   return (
     <Wrapper>
@@ -50,7 +35,11 @@ const Main = () => {
       <Logo src={logo} alt="logo" />
       <SearchMessage>피움에 등록된 식물을 검색해 보세요!</SearchMessage>
       <SearchBoxArea>
-        <SearchBox onEnter={search} onNextClick={search} onResultClick={goToDictDetailPage} />
+        <SearchBox
+          onEnter={goToProperDictPage}
+          onNextClick={goToProperDictPage}
+          onResultClick={goToDictDetailPage}
+        />
       </SearchBoxArea>
     </Wrapper>
   );

--- a/frontend/src/pages/PetRegister/Form/Form.style.ts
+++ b/frontend/src/pages/PetRegister/Form/Form.style.ts
@@ -12,7 +12,8 @@ export const Wrapper = styled.div`
 `;
 
 export const FormArea = styled.div`
-  overflow: scroll;
+  overflow-x: none;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/frontend/src/pages/PetRegister/Form/index.tsx
+++ b/frontend/src/pages/PetRegister/Form/index.tsx
@@ -191,7 +191,7 @@ const PetRegisterForm = () => {
                   '5m 내 창문이 있어요',
                   '5m 보다 멀리 창문이 있어요',
                   '창문이 없지만 바람이 통해요',
-                  '바람이 안통해요',
+                  '바람이 안 통해요',
                 ]}
                 onChange={setWind}
                 placeholder="통풍을 선택해 주세요"

--- a/frontend/src/pages/PetRegister/Form/index.tsx
+++ b/frontend/src/pages/PetRegister/Form/index.tsx
@@ -18,7 +18,7 @@ import {
 } from './Form.style';
 import DictAPI from 'apis/dictionary';
 import petPlantsAPI from 'apis/pet';
-import { URL_PATH } from 'constants/index';
+import { NUMBER, URL_PATH } from 'constants/index';
 import { usePetPlantForm } from './reducer';
 
 const PetRegisterForm = () => {
@@ -51,7 +51,13 @@ const PetRegisterForm = () => {
   };
 
   const setWaterCycle = ({ target: { value } }: React.ChangeEvent<HTMLInputElement>) => {
-    dispatch({ type: 'SET_NUMBER_INPUT', key: 'waterCycle', value });
+    dispatch({
+      type: 'SET_NUMBER_INPUT',
+      key: 'waterCycle',
+      value,
+      min: NUMBER.MIN_CYCLE_DATE,
+      max: NUMBER.MAX_CYCLE_DATE,
+    });
   };
 
   const validateWaterCycle = () => {

--- a/frontend/src/pages/PetRegister/Search/index.tsx
+++ b/frontend/src/pages/PetRegister/Search/index.tsx
@@ -14,7 +14,7 @@ const PetRegisterSearch = () => {
     <Wrapper>
       <Message>어떤 식물을 키우시나요?</Message>
       <SearchBoxArea>
-        <SearchBox onSelect={navigateForm} />
+        <SearchBox onResultClick={navigateForm} />
       </SearchBoxArea>
     </Wrapper>
   );

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react';
 import { createBrowserRouter } from 'react-router-dom';
 import DictionaryDetail from 'pages/DictionaryDetail';
+import DictionarySearch from 'pages/DictionarySearch';
 import Main from 'pages/Main';
 import PetRegisterForm from 'pages/PetRegister/Form';
 import PetRegisterSearch from 'pages/PetRegister/Search';
@@ -23,6 +24,10 @@ const router = createBrowserRouter([
       {
         path: URL_PATH.PET_REGISTER_FORM,
         element: <PetRegisterForm />,
+      },
+      {
+        path: '/dict',
+        element: <DictionarySearch />,
       },
       {
         path: URL_PATH.DICT,

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -1,12 +1,19 @@
-// YYYY-MM-DD 형태로 받은 날짜를 YYYY년 MM월 DD일로 변경
-export const convertDateKorYear = (date: string) =>
+/**
+ * 받은 날짜를 한국식으로 표현합니다.
+ * @param date `new Date()`를 이용해 날짜 형태로 변경할 수 있는 값
+ * @returns 'YYYY년 MM월 DD일'
+ */
+export const convertDateKorYear = (date: string | number | Date) =>
   new Date(date).toLocaleDateString('ko-KR', {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
   });
 
-// 오늘 날짜를 YYYY-MM-DD 형태로 받기
+/**
+ * 오늘 날짜를 YYYY-MM-DD 형태의 string으로 반환합니다.
+ * @returns 'YYYY-MM-DD'
+ */
 export const getToday = () => {
   const timezoneOffset = new Date().getTimezoneOffset() * 60 * 1000;
   const localTime = new Date(Date.now() - timezoneOffset);

--- a/frontend/src/utils/getFilteredChildren.ts
+++ b/frontend/src/utils/getFilteredChildren.ts
@@ -1,5 +1,12 @@
 import { Children, isValidElement } from 'react';
 
+/**
+ * 직속 자녀들 중 특정 컴포넌트만 추려냅니다.
+ * @param childElement 찾고 싶은 컴포넌트
+ * @param childrenProp 이 함수를 사용하는 컴포넌트의 `children` prop
+ * @param count 최대 몇 개까지 찾을 것인지
+ * @returns 찾은 컴포넌트들의 배열
+ */
 const getFilteredChildren = (
   childElement: JSX.Element,
   childrenProp: React.ReactNode,

--- a/frontend/src/utils/parseTemperature.ts
+++ b/frontend/src/utils/parseTemperature.ts
@@ -1,0 +1,15 @@
+/**
+ * 공공데이터 API에 들어있는 겨울철 최저온도 문자열을 파싱합니다.
+ * @param tempString '13도', '13도 이상', '0도 이하' 등의 문자열
+ * @returns `type`: 이상 | 이하, `temperature`: 나머지 문자열
+ */
+const parseTemperature = (tempString: string): { temperature: string; type: '이상' | '이하' } => {
+  const hasLowEqualText = tempString.includes('이하');
+
+  const temperature = tempString.replace('이상', '').replace('이하', '').trim();
+  const type = hasLowEqualText ? '이하' : '이상';
+
+  return { temperature, type };
+};
+
+export default parseTemperature;

--- a/frontend/src/utils/validate.ts
+++ b/frontend/src/utils/validate.ts
@@ -1,12 +1,22 @@
 export const inputValidate = {
-  // 입력 값이 0~9인지 확인하는 메서드
+  /**
+   * 값이 0~9로만 이루어진 숫자인지 확인합니다.
+   * @param value 문자열 형태로 된 숫자
+   * @returns 아라비아 숫자로만 이루어져 있으면 `true`
+   */
   checkNumber: (value: string) => {
     const regExp = /^[0-9]+$/;
 
     return regExp.test(value);
   },
 
-  // 입력받은 값이 범위 내에 있는지 확인하는 메서드
+  /**
+   * 입력받은 값이 범위 내에 있는지 확인하는 메서드
+   * @param value 문자열 형태로 된 숫자
+   * @param start 가능한 `value`의 최솟값
+   * @param end 가능한 `value`의 최댓값
+   * @returns 닫힌 구간 내에 있으면 `true`
+   */
   checkRange: (value: number, start?: number, end?: number) => {
     if (start && end) {
       return value >= start && value <= end;
@@ -23,6 +33,10 @@ export const inputValidate = {
     return true;
   },
 
-  // 숫자외에 다른 값들이 들어가있는지 확인하는 메서드
+  /**
+   * (number input에서) 순수한 숫자 외에 다른 값들이 들어가 있는지 확인합니다.
+   * @param value 문자열 형태로 된 숫자
+   * @returns 'e', 'E', '+', '-', '.'가 없으면 `true`
+   */
   checkECode: (value: string) => ['e', 'E', '+', '-', '.'].includes(value),
 };


### PR DESCRIPTION
# 🔥 연관 이슈

- close #92

# 🚀 작업 내용

### 사전 검색 결과 목록 페이지
- 검색창에서 검색 시 일치하는 결과가 있으면 사전 상세 정보로 이동
- 없으면 사전 검색 결과 목록 페이지로 이동

### SearchBox props 변경
- 검색 결과 클릭, 엔타, 화살표 버튼 클릭에 대한 핸들러를 받음

### 각종 디테일 수정
- msw 적용 안되는 버그 수정
- 유틸함수에 tsdoc 추가
- 스토리북 action 몇 개 추가
- 사전 검색하는 로직 훅으로 분리
- 겨울 최저온도 파싱 로직 추가 (공공데이터가 '13도', '13도 이상', '0도 이하' 처럼 중구난방하게 줘서 좀 개선했어요)
- 등록 폼 스크롤 보이는 문제 해결
- 띄어쓰기 수정
- 라디오 버튼에 커서 포인터 추가
- 냄새 이모지가 윈도우에서 깨지는 현상 수정
- 스타일드 컴포넌트 props를 DOM으로 넘겨줘서 발생하는 에러 해결


# 💬 리뷰 중점사항

작업 내용이 좀 중구난방합니다.
커밋메시지로 대략적인 흐름을 적어놨어요
