### PR TITLE
refactor: 식물 사전 검색 결과 리팩터링, 데모데이 피드백 반영, 버그 수정

### DIFF
--- a/.github/workflows/frontend-dev.yml
+++ b/.github/workflows/frontend-dev.yml
@@ -55,5 +55,5 @@ jobs:
           author_name: 프론트엔드 빌드 결과 알림
           fields: repo, message, commit, author, action, eventName, ref, workflow, job, took
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FRONTEND }}
         if: always()

--- a/frontend/src/components/@common/ProgressBar/ProgressBar.stories.tsx
+++ b/frontend/src/components/@common/ProgressBar/ProgressBar.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import theme from 'style/theme.style';
+import ProgressBar from '.';
+
+const meta: Meta<typeof ProgressBar> = {
+  component: ProgressBar,
+
+  args: {
+    color: theme.color.primary,
+    height: '10px',
+    width: '100%',
+    percentage: 50,
+  },
+
+  argTypes: {
+    color: {
+      control: { type: 'color' },
+    },
+    percentage: {
+      control: {
+        type: 'range',
+        min: 0,
+        max: 100,
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ProgressBar>;
+
+export const Default: Story = {};

--- a/frontend/src/components/@common/ProgressBar/ProgressBar.style.ts
+++ b/frontend/src/components/@common/ProgressBar/ProgressBar.style.ts
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+
+interface WrapperProps {
+  $width: string | undefined;
+  $height: string | undefined;
+}
+
+interface BarProps {
+  $color: string | undefined;
+  $percentage: number | undefined;
+}
+
+export const Wrapper = styled.div<WrapperProps>`
+  width: ${({ $width = '100%' }) => $width};
+  height: ${({ $height = '10px' }) => $height};
+  border: 1px solid ${({ theme }) => theme.color.gray};
+  border-radius: 5px;
+`;
+
+export const Bar = styled.div<BarProps>`
+  width: ${({ $percentage = 0 }) => $percentage}%;
+  height: 100%;
+
+  background-color: ${({ $color, theme }) => $color ?? theme.color.primary};
+  border-radius: 5px;
+
+  transition: all 0.5s ease-out;
+`;

--- a/frontend/src/components/@common/ProgressBar/index.tsx
+++ b/frontend/src/components/@common/ProgressBar/index.tsx
@@ -1,0 +1,21 @@
+import { Bar, Wrapper } from './ProgressBar.style';
+
+interface ProgressBarProps {
+  percentage: number;
+  width?: string;
+  height?: string;
+  color?: string;
+}
+
+const ProgressBar = (props: ProgressBarProps) => {
+  const { percentage, width, height, color } = props;
+  const barWidth = Math.min(Math.max(percentage, 0), 100);
+
+  return (
+    <Wrapper $height={height} $width={width}>
+      <Bar $color={color} $percentage={barWidth} />
+    </Wrapper>
+  );
+};
+
+export default ProgressBar;

--- a/frontend/src/components/FormInput/index.tsx
+++ b/frontend/src/components/FormInput/index.tsx
@@ -12,9 +12,11 @@ const FormInput = (props: FormInputProps) => {
   return (
     <Wrapper>
       <Input type="text" {...inputProps} />
-      <Button>
-        {nextCallback && <ArrowRight width={20} height={20} onClick={nextCallback} />}
-      </Button>
+      {nextCallback && (
+        <Button type="button" aria-label="입력 완료" onClick={nextCallback}>
+          <ArrowRight width={20} height={20} />
+        </Button>
+      )}
     </Wrapper>
   );
 };

--- a/frontend/src/components/SearchResults/index.tsx
+++ b/frontend/src/components/SearchResults/index.tsx
@@ -18,7 +18,7 @@ const SearchResults = (props: SearchResultsProps) => {
   if (!searchResults || (!samePlant && !hasSimilarPlant)) {
     return (
       <Wrapper>
-        <Title>&quot;{plantName}&quot; 검색 결과가 없어요 😭</Title>
+        <Title>검색 결과가 없어요 😭</Title>
       </Wrapper>
     );
   }

--- a/frontend/src/hooks/useDictrionaryNavigate.ts
+++ b/frontend/src/hooks/useDictrionaryNavigate.ts
@@ -1,12 +1,13 @@
 import type { DictNameSearchResult } from 'types/api/dictionary';
 import { useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, generatePath } from 'react-router-dom';
+import { URL_PATH } from 'constants/index';
 
 const useDictionaryNavigate = () => {
   const navigate = useNavigate();
 
   const goToDictDetailPage = useCallback((plantId: number) => {
-    navigate(`/dict/${plantId}`);
+    navigate(generatePath(URL_PATH.dictDetail, { id: plantId.toString() }));
   }, []);
 
   const goToProperDictPage = useCallback(

--- a/frontend/src/pages/DictionarySearch/DictionarySearch.style.ts
+++ b/frontend/src/pages/DictionarySearch/DictionarySearch.style.ts
@@ -6,3 +6,8 @@ export const Wrapper = styled.div`
   row-gap: 30px;
   padding: 30px 10px;
 `;
+
+export const Title = styled.h1`
+  padding-left: 10px;
+  font: ${({ theme }) => theme.font.title};
+`;

--- a/frontend/src/pages/DictionarySearch/index.tsx
+++ b/frontend/src/pages/DictionarySearch/index.tsx
@@ -1,7 +1,7 @@
 import { useSearchParams } from 'react-router-dom';
 import SearchBox from 'components/SearchBox';
 import SearchResults from 'components/SearchResults';
-import { Wrapper } from './DictionarySearch.style';
+import { Title, Wrapper } from './DictionarySearch.style';
 import useDictionaryNavigate from 'hooks/useDictrionaryNavigate';
 
 const DictionarySearch = () => {
@@ -17,6 +17,7 @@ const DictionarySearch = () => {
         onNextClick={goToProperDictPage}
         onResultClick={goToDictDetailPage}
       />
+      <Title>&quot;{search}&quot; 검색 결과</Title>
       <SearchResults plantName={search} />
     </Wrapper>
   );

--- a/frontend/src/pages/Main/index.tsx
+++ b/frontend/src/pages/Main/index.tsx
@@ -25,7 +25,9 @@ const Main = () => {
   return (
     <Wrapper>
       <ButtonArea>
-        <StartButton onClick={navigateRegister}>시작하기</StartButton>
+        <StartButton type="button" onClick={navigateRegister}>
+          시작하기
+        </StartButton>
       </ButtonArea>
       <LogoMessage>식물을 쉽게</LogoMessage>
       <Logo src={logo} alt="logo" />

--- a/frontend/src/pages/PetRegister/Form/Form.style.ts
+++ b/frontend/src/pages/PetRegister/Form/Form.style.ts
@@ -32,9 +32,13 @@ export const DictionaryPlantImageArea = styled.div`
   margin: 32px 0;
 `;
 
-export const ButtonArea = styled.div`
+export const ProgressBarArea = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
   width: 100%;
-  margin-top: 16px;
+  margin: 16px auto;
 `;
 
 export const Button = styled.button`

--- a/frontend/src/pages/PetRegister/Form/Form.style.ts
+++ b/frontend/src/pages/PetRegister/Form/Form.style.ts
@@ -32,7 +32,7 @@ export const DictionaryPlantImageArea = styled.div`
   margin: 32px 0;
 `;
 
-export const ProgressBarArea = styled.div`
+export const Center = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -42,15 +42,17 @@ export const ProgressBarArea = styled.div`
 `;
 
 export const Button = styled.button`
-  width: 100%;
-  height: 40px;
+  width: 90%;
+  height: 48px;
 
-  font-size: 1.8rem;
-  font-weight: 500;
-  color: ${(props) => props.theme.color.sub};
+  font-size: 2rem;
+  font-weight: 900;
+  line-height: 2.4rem;
+  color: ${({ theme }) => theme.color.background};
+  letter-spacing: 1px;
 
   background: ${(props) => props.theme.color.primary};
-  border-radius: 16px;
+  border-radius: 8px;
 
   &:disabled {
     color: ${(props) => props.theme.color.sub + '40'};

--- a/frontend/src/pages/PetRegister/Form/index.tsx
+++ b/frontend/src/pages/PetRegister/Form/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import ProgressBar from 'components/@common/ProgressBar';
 import DateInput from 'components/DateInput';
 import FormInput from 'components/FormInput';
 import FormInputBox from 'components/FormInputBox';
@@ -9,7 +10,7 @@ import Stack from 'components/Stack';
 import useStack from 'components/Stack/hooks/useStack';
 import {
   Button,
-  ButtonArea,
+  ProgressBarArea,
   DictionaryPlantImageArea,
   DictionaryPlantName,
   FormArea,
@@ -20,16 +21,19 @@ import PetAPI from 'apis/pet';
 import { NUMBER, OPTIONS, URL_PATH } from 'constants/index';
 import { usePetPlantForm } from './reducer';
 
+const STACK_SIZE = 9;
+const STACK_ELEMENT_HEIGHT = '96px';
+
 const PetRegisterForm = () => {
   const { id } = useParams();
   const dictionaryPlantId = Number(id);
-  const { topIndex, showNextElement } = useStack(9);
+  const { topIndex, showNextElement } = useStack(STACK_SIZE);
   const { form, dispatch } = usePetPlantForm();
   const navigate = useNavigate();
 
   const { data: dictionaryPlant } = useDictDetail(dictionaryPlantId);
 
-  const stackElementHeight = '96px';
+  const formProgressPercentage = Math.floor((topIndex / (STACK_SIZE - 1)) * 100);
 
   const setNickname = ({ target: { value } }: React.ChangeEvent<HTMLInputElement>) => {
     dispatch({ type: 'SET', key: 'nickname', value });
@@ -111,8 +115,11 @@ const PetRegisterForm = () => {
         <DictionaryPlantImageArea>
           <Image size="160px" src={dictionaryPlant?.image} />
         </DictionaryPlantImageArea>
+        <ProgressBarArea>
+          <ProgressBar percentage={formProgressPercentage} width="90%" height="12px" />
+        </ProgressBarArea>
         <Stack topIndex={topIndex}>
-          <Stack.Element height={stackElementHeight}>
+          <Stack.Element height={STACK_ELEMENT_HEIGHT}>
             <FormInputBox title="별명이 뭔가요?" status={getStatus(0)}>
               <FormInput
                 value={form.nickname}
@@ -121,17 +128,17 @@ const PetRegisterForm = () => {
               />
             </FormInputBox>
           </Stack.Element>
-          <Stack.Element height={stackElementHeight}>
+          <Stack.Element height={STACK_ELEMENT_HEIGHT}>
             <FormInputBox title="생일(입양일)이 언제인가요?" status={getStatus(1)}>
               <DateInput value={form.birthDate} onChange={setBirthDate} />
             </FormInputBox>
           </Stack.Element>
-          <Stack.Element height={stackElementHeight}>
+          <Stack.Element height={STACK_ELEMENT_HEIGHT}>
             <FormInputBox title="마지막으로 물 준 날짜가 언제인가요?" status={getStatus(2)}>
               <DateInput value={form.lastWaterDate} onChange={setLastWaterDate} />
             </FormInputBox>
           </Stack.Element>
-          <Stack.Element height={stackElementHeight}>
+          <Stack.Element height={STACK_ELEMENT_HEIGHT}>
             <FormInputBox title="며칠 주기로 물을 주나요?" status={getStatus(3)}>
               <FormInput
                 value={form.waterCycle}
@@ -140,7 +147,7 @@ const PetRegisterForm = () => {
               />
             </FormInputBox>
           </Stack.Element>
-          <Stack.Element height={stackElementHeight}>
+          <Stack.Element height={STACK_ELEMENT_HEIGHT}>
             <FormInputBox title="어떤 화분에서 키우고 있나요?" status={getStatus(4)}>
               <Select
                 value={form.flowerpot}
@@ -150,7 +157,7 @@ const PetRegisterForm = () => {
               />
             </FormInputBox>
           </Stack.Element>
-          <Stack.Element height={stackElementHeight}>
+          <Stack.Element height={STACK_ELEMENT_HEIGHT}>
             <FormInputBox title="화분의 위치는 어디인가요?" status={getStatus(5)}>
               <Select
                 value={form.location}
@@ -160,7 +167,7 @@ const PetRegisterForm = () => {
               />
             </FormInputBox>
           </Stack.Element>
-          <Stack.Element height={stackElementHeight}>
+          <Stack.Element height={STACK_ELEMENT_HEIGHT}>
             <FormInputBox title="빛을 어떻게 받고 있나요?" status={getStatus(6)}>
               <Select
                 value={form.light}
@@ -170,7 +177,7 @@ const PetRegisterForm = () => {
               />
             </FormInputBox>
           </Stack.Element>
-          <Stack.Element height={stackElementHeight}>
+          <Stack.Element height={STACK_ELEMENT_HEIGHT}>
             <FormInputBox title="바람은 얼마나 통하나요?" status={getStatus(7)}>
               <Select
                 value={form.wind}
@@ -180,18 +187,13 @@ const PetRegisterForm = () => {
               />
             </FormInputBox>
           </Stack.Element>
-          <Stack.Element height={stackElementHeight}>
+          <Stack.Element height={STACK_ELEMENT_HEIGHT}>
             <Button type="submit" onClick={submit} disabled={!isValidForm}>
               등록하기
             </Button>
           </Stack.Element>
         </Stack>
       </FormArea>
-      <ButtonArea>
-        <Button type="submit" onClick={submit} disabled={!isValidForm}>
-          등록하기
-        </Button>
-      </ButtonArea>
     </Wrapper>
   );
 };

--- a/frontend/src/pages/PetRegister/Form/index.tsx
+++ b/frontend/src/pages/PetRegister/Form/index.tsx
@@ -10,7 +10,7 @@ import Stack from 'components/Stack';
 import useStack from 'components/Stack/hooks/useStack';
 import {
   Button,
-  ProgressBarArea,
+  Center,
   DictionaryPlantImageArea,
   DictionaryPlantName,
   FormArea,
@@ -115,9 +115,9 @@ const PetRegisterForm = () => {
         <DictionaryPlantImageArea>
           <Image size="160px" src={dictionaryPlant?.image} />
         </DictionaryPlantImageArea>
-        <ProgressBarArea>
+        <Center>
           <ProgressBar percentage={formProgressPercentage} width="90%" height="12px" />
-        </ProgressBarArea>
+        </Center>
         <Stack topIndex={topIndex}>
           <Stack.Element height={STACK_ELEMENT_HEIGHT}>
             <FormInputBox title="별명이 뭔가요?" status={getStatus(0)}>
@@ -188,9 +188,11 @@ const PetRegisterForm = () => {
             </FormInputBox>
           </Stack.Element>
           <Stack.Element height={STACK_ELEMENT_HEIGHT}>
-            <Button type="submit" onClick={submit} disabled={!isValidForm}>
-              등록하기
-            </Button>
+            <Center>
+              <Button type="submit" onClick={submit} disabled={!isValidForm}>
+                등록하기
+              </Button>
+            </Center>
           </Stack.Element>
         </Stack>
       </FormArea>

--- a/frontend/src/pages/PetRegister/Form/index.tsx
+++ b/frontend/src/pages/PetRegister/Form/index.tsx
@@ -23,7 +23,7 @@ import { usePetPlantForm } from './reducer';
 const PetRegisterForm = () => {
   const { id } = useParams();
   const dictionaryPlantId = Number(id);
-  const { topIndex, showNextElement } = useStack(8);
+  const { topIndex, showNextElement } = useStack(9);
   const { form, dispatch } = usePetPlantForm();
   const navigate = useNavigate();
 
@@ -179,6 +179,11 @@ const PetRegisterForm = () => {
                 placeholder="통풍을 선택해 주세요"
               />
             </FormInputBox>
+          </Stack.Element>
+          <Stack.Element height={stackElementHeight}>
+            <Button type="submit" onClick={submit} disabled={!isValidForm}>
+              등록하기
+            </Button>
           </Stack.Element>
         </Stack>
       </FormArea>

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -23,7 +23,11 @@ const router = createBrowserRouter([
       },
       {
         path: URL_PATH.petRegisterForm,
-        element: <PetRegisterForm />,
+        element: (
+          <Suspense fallback={<div>로딩중입니다.</div>}>
+            <PetRegisterForm />
+          </Suspense>
+        ),
       },
       {
         path: '/dict',


### PR DESCRIPTION
# 🔥 연관 이슈

- close #128 

# 🚀 작업 내용

### 데모데이 피드백 관련

- 폼 입력 다 하면 Stack을 이용해서 맨 위에도 완료 버튼을 보여줍니다.
    맨 밑에 버튼을 없애지 않은 이유는 1. 폼 미완일 때 미완임을 명시하기 위함 2. 사용자가 재확인을 위해 아래로 이동했을 때도 바로 등록 가능하게 하기 위함입니다.
![image](https://github.com/woowacourse-teams/2023-pium/assets/77872742/90c38b94-fa7c-4a60-99c7-6dc23c881cde)


- 검색 결과 페이지에서 검색어를 표시합니다.
![image](https://github.com/woowacourse-teams/2023-pium/assets/77872742/2fea1c30-11f8-4b3f-8684-a948c0c6acd9)
![image](https://github.com/woowacourse-teams/2023-pium/assets/77872742/95a41151-db63-4ee4-8faf-4232c03d3a9d)

### 코드 리뷰 관련

- generatePath 적용했습니다. 쿼리스트링 쪽도 한번 해봤는데 안되더라구요ㅠ 일단 거기는 냅뒀습니다
- 버튼 접근성 개선: Button 태그에 onClick을 다는 방향으로 리팩터링 진행했어요

### 버그 수정 (중요도 높음)

- 현재 배포 서버에서도 나오는 현상인데 식물 등록할 때 검색 후 식물 선택하면 앱이 터집니다.
- 원인: useQuery의 suspense가 true인데 suspense가 없어서
- 해결: suspense 대충 추가

**제가 시간 내서 Cypress 전격 도입하겠습니다**

# 💬 리뷰 중점사항
