### PR TITLE
refactor: 사용자 인증방식 추가

### DIFF
--- a/backend/pium/src/main/java/com/official/pium/config/MemberArgumentResolver.java
+++ b/backend/pium/src/main/java/com/official/pium/config/MemberArgumentResolver.java
@@ -1,5 +1,6 @@
 package com.official.pium.config;
 
+import com.official.pium.domain.Auth;
 import com.official.pium.domain.Member;
 import com.official.pium.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,13 +17,16 @@ public class MemberArgumentResolver implements HandlerMethodArgumentResolver {
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        return parameter.getParameterType().equals(Member.class);
+        return parameter.hasParameterAnnotation(Auth.class) && parameter.getParameterType().equals(Member.class);
     }
 
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
-        return memberRepository.findByEmail("pium@gmail.com")
+
+        String token = webRequest.getHeader("Authorization");
+
+        return memberRepository.findByEmail(token)
                 .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
     }
 }

--- a/backend/pium/src/main/java/com/official/pium/controller/PetPlantController.java
+++ b/backend/pium/src/main/java/com/official/pium/controller/PetPlantController.java
@@ -1,5 +1,6 @@
 package com.official.pium.controller;
 
+import com.official.pium.domain.Auth;
 import com.official.pium.domain.Member;
 import com.official.pium.service.PetPlantService;
 import com.official.pium.service.dto.DataResponse;
@@ -34,14 +35,14 @@ public class PetPlantController {
     @PostMapping
     public ResponseEntity<Void> create(
             @RequestBody @Valid PetPlantRequest request,
-            Member member) {
+            @Auth Member member) {
         PetPlantResponse petPlantResponse = petPlantService.create(request, member);
         return ResponseEntity.created(URI.create("/pet-plants/" + petPlantResponse.getId())).build();
     }
 
     @GetMapping
     public ResponseEntity<DataResponse<List<SinglePetPlantResponse>>> readAll(
-            Member member) {
+            @Auth Member member) {
         DataResponse<List<SinglePetPlantResponse>> response = petPlantService.readAll(member);
         return ResponseEntity.ok(response);
     }

--- a/backend/pium/src/main/java/com/official/pium/controller/PetPlantController.java
+++ b/backend/pium/src/main/java/com/official/pium/controller/PetPlantController.java
@@ -27,7 +27,8 @@ public class PetPlantController {
 
     @GetMapping("/{id}")
     public ResponseEntity<PetPlantResponse> read(
-            @PathVariable @Positive(message = "반려 식물 ID는 1이상의 값이어야 합니다.") Long id) {
+            @PathVariable @Positive(message = "반려 식물 ID는 1이상의 값이어야 합니다.") Long id,
+            @Auth Member member) {
         PetPlantResponse petPlantResponse = petPlantService.read(id);
         return ResponseEntity.ok(petPlantResponse);
     }

--- a/backend/pium/src/main/java/com/official/pium/domain/Auth.java
+++ b/backend/pium/src/main/java/com/official/pium/domain/Auth.java
@@ -1,0 +1,12 @@
+package com.official.pium.domain;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+
+@Target({PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Auth {
+}

--- a/backend/pium/src/test/java/com/official/pium/RepositoryTest.java
+++ b/backend/pium/src/test/java/com/official/pium/RepositoryTest.java
@@ -1,0 +1,13 @@
+package com.official.pium;
+
+import com.official.pium.config.JpaAuditingConfig;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+
+@DataJpaTest(includeFilters = @ComponentScan.Filter(
+        type = FilterType.ASSIGNABLE_TYPE,
+        classes = JpaAuditingConfig.class
+))
+public class RepositoryTest {
+}

--- a/backend/pium/src/test/java/com/official/pium/UITest.java
+++ b/backend/pium/src/test/java/com/official/pium/UITest.java
@@ -1,15 +1,16 @@
 package com.official.pium;
 
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
-
 import com.official.pium.config.WebMvcConfigure;
 import com.official.pium.domain.Member;
 import com.official.pium.repository.MemberRepository;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 @Import(value = {WebMvcConfigure.class})
 public class UITest {
@@ -19,9 +20,11 @@ public class UITest {
 
     @BeforeEach
     void setUp() {
-        given(memberRepository.findByEmail(anyString()))
-                .willReturn(Optional.of(Member.builder()
-                        .email("pium@gmail.com")
-                        .build()));
+        given(memberRepository.findByEmail(any()))
+                .willReturn(
+                        Optional.of(Member.builder()
+                                .email("pium@gmail.com")
+                                .build())
+                );
     }
 }

--- a/backend/pium/src/test/java/com/official/pium/repository/DictionaryPlantRepositoryTest.java
+++ b/backend/pium/src/test/java/com/official/pium/repository/DictionaryPlantRepositoryTest.java
@@ -1,18 +1,17 @@
 package com.official.pium.repository;
 
+import com.official.pium.RepositoryTest;
 import com.official.pium.domain.DictionaryPlant;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
-@DataJpaTest
-class DictionaryPlantRepositoryTest {
+class DictionaryPlantRepositoryTest extends RepositoryTest {
 
     @Autowired
     private DictionaryPlantRepository dictionaryPlantRepository;

--- a/backend/pium/src/test/java/com/official/pium/repository/MemberRepositoryTest.java
+++ b/backend/pium/src/test/java/com/official/pium/repository/MemberRepositoryTest.java
@@ -1,25 +1,18 @@
 package com.official.pium.repository;
 
-import com.official.pium.config.JpaAuditingConfig;
+import com.official.pium.RepositoryTest;
 import com.official.pium.domain.Member;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
-@DataJpaTest(includeFilters = @ComponentScan.Filter(
-        type = FilterType.ASSIGNABLE_TYPE,
-        classes = JpaAuditingConfig.class
-))
-class MemberRepositoryTest {
+class MemberRepositoryTest extends RepositoryTest {
 
     @Autowired
     private MemberRepository memberRepository;

--- a/backend/pium/src/test/java/com/official/pium/repository/MemberRepositoryTest.java
+++ b/backend/pium/src/test/java/com/official/pium/repository/MemberRepositoryTest.java
@@ -1,18 +1,24 @@
 package com.official.pium.repository;
 
+import com.official.pium.config.JpaAuditingConfig;
 import com.official.pium.domain.Member;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
-@DataJpaTest
+@DataJpaTest(includeFilters = @ComponentScan.Filter(
+        type = FilterType.ASSIGNABLE_TYPE,
+        classes = JpaAuditingConfig.class
+))
 class MemberRepositoryTest {
 
     @Autowired
@@ -20,7 +26,9 @@ class MemberRepositoryTest {
 
     @Test
     void 사용자_저장() {
-        Member member = Member.builder().email("hello@aaa.com").build();
+        Member member = Member.builder()
+                .email("hello@aaa.com")
+                .build();
 
         Member save = memberRepository.save(member);
 

--- a/backend/pium/src/test/java/com/official/pium/repository/PetPlantRepositoryTest.java
+++ b/backend/pium/src/test/java/com/official/pium/repository/PetPlantRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.official.pium.repository;
 
+import com.official.pium.RepositoryTest;
 import com.official.pium.domain.DictionaryPlant;
 import com.official.pium.domain.Member;
 import com.official.pium.domain.PetPlant;
@@ -8,7 +9,6 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.time.LocalDate;
 
@@ -17,8 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
-@DataJpaTest
-class PetPlantRepositoryTest {
+class PetPlantRepositoryTest extends RepositoryTest {
 
     private Member member;
     private DictionaryPlant dictionaryPlant;


### PR DESCRIPTION
# 🔥 연관 이슈

- close #98 

# 🚀 작업 내용

- [x] Auth 어노테이션 추가
  -  MemberArgumentResolver에서 Member 클래스와 Auth 어노테이션 유무를 확인합니다.
- [x] DataJpaTest 상속구조로 변경
- [x] 인증방식 수정
  - MemberArgumentResolver에서 Authorization 헤더를 확인합니다.

# 💬 리뷰 중점사항

인증이 필요한 부분에 누락된 사항이 없는지 확인 부탁드립니다.