### PR TITLE
refactor: 리마인더 조회 정렬 추가

### DIFF
--- a/backend/pium/src/main/java/com/official/pium/repository/PetPlantRepository.java
+++ b/backend/pium/src/main/java/com/official/pium/repository/PetPlantRepository.java
@@ -1,6 +1,7 @@
 package com.official.pium.repository;
 
 import com.official.pium.domain.PetPlant;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -8,4 +9,5 @@ import java.util.List;
 public interface PetPlantRepository extends JpaRepository<PetPlant, Long> {
 
     List<PetPlant> findAllByMemberId(Long memberId);
+    List<PetPlant> findAllByMemberId(Long memberId, Sort sort);
 }

--- a/backend/pium/src/main/java/com/official/pium/service/ReminderService.java
+++ b/backend/pium/src/main/java/com/official/pium/service/ReminderService.java
@@ -59,7 +59,7 @@ public class ReminderService {
     }
 
     public DataResponse<List<ReminderResponse>> readAll(Member member) {
-        List<PetPlant> petPlants = petPlantRepository.findAllByMemberId(member.getId(), Sort.by(Direction.DESC, "nextWaterDate"));
+        List<PetPlant> petPlants = petPlantRepository.findAllByMemberId(member.getId(), Sort.by(Direction.ASC, "nextWaterDate"));
 
         List<ReminderResponse> reminderResponses = petPlants.stream()
                 .map(petPlant -> PetPlantMapper.toReminderResponse(

--- a/backend/pium/src/main/java/com/official/pium/service/ReminderService.java
+++ b/backend/pium/src/main/java/com/official/pium/service/ReminderService.java
@@ -14,6 +14,8 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -57,7 +59,7 @@ public class ReminderService {
     }
 
     public DataResponse<List<ReminderResponse>> readAll(Member member) {
-        List<PetPlant> petPlants = petPlantRepository.findAllByMemberId(member.getId());
+        List<PetPlant> petPlants = petPlantRepository.findAllByMemberId(member.getId(), Sort.by(Direction.DESC, "nextWaterDate"));
 
         List<ReminderResponse> reminderResponses = petPlants.stream()
                 .map(petPlant -> PetPlantMapper.toReminderResponse(

--- a/backend/pium/src/test/java/com/official/pium/service/ReminderServiceTest.java
+++ b/backend/pium/src/test/java/com/official/pium/service/ReminderServiceTest.java
@@ -154,14 +154,42 @@ class ReminderServiceTest extends IntegrationTest {
 
     @Test
     void 리마인더_전체_조회() {
+        PetPlant petPlant1 = savePetPlantWithNextWaterDate(LocalDate.now().plusDays(1));
+        PetPlant petPlant2 = savePetPlantWithNextWaterDate(LocalDate.now().plusDays(2));
+        PetPlant petPlant3 = savePetPlantWithNextWaterDate(LocalDate.now().plusDays(3));
+        PetPlant petPlant4 = savePetPlantWithNextWaterDate(LocalDate.now().plusDays(4));
+
         DataResponse<List<ReminderResponse>> actual = reminderService.readAll(petPlant.getMember());
 
+
         List<ReminderResponse> expected = List.of(
-                PetPlantMapper.toReminderResponse(petPlant, petPlant.calculateDDay(LocalDate.now())));
+                PetPlantMapper.toReminderResponse(petPlant4, petPlant4.calculateDDay(LocalDate.now())),
+                PetPlantMapper.toReminderResponse(petPlant3, petPlant3.calculateDDay(LocalDate.now())),
+                PetPlantMapper.toReminderResponse(petPlant2, petPlant2.calculateDDay(LocalDate.now())),
+                PetPlantMapper.toReminderResponse(petPlant1, petPlant1.calculateDDay(LocalDate.now())),
+                PetPlantMapper.toReminderResponse(petPlant, petPlant.calculateDDay(LocalDate.now()))
+        );
 
         assertThat(actual.getData())
-                .hasSize(1)
+                .hasSize(expected.size())
                 .usingRecursiveComparison()
                 .isEqualTo(expected);
+    }
+
+    private PetPlant savePetPlantWithNextWaterDate(LocalDate nextWaterDate) {
+        return petPlantRepository.save(PetPlant.builder()
+                .dictionaryPlant(petPlant.getDictionaryPlant())
+                .member(member)
+                .nickname("testNickName")
+                .imageUrl("testImageUrl")
+                .location("testLocation")
+                .flowerpot("testFlowerpot")
+                .light("testLight")
+                .wind("testWind")
+                .birthDate(LocalDate.now())
+                .nextWaterDate(nextWaterDate)
+                .lastWaterDate(LocalDate.now().minusDays(1))
+                .waterCycle(3)
+                .build());
     }
 }

--- a/backend/pium/src/test/java/com/official/pium/service/ReminderServiceTest.java
+++ b/backend/pium/src/test/java/com/official/pium/service/ReminderServiceTest.java
@@ -161,7 +161,6 @@ class ReminderServiceTest extends IntegrationTest {
 
         DataResponse<List<ReminderResponse>> actual = reminderService.readAll(petPlant.getMember());
 
-
         List<ReminderResponse> expected = List.of(
                 PetPlantMapper.toReminderResponse(petPlant, petPlant.calculateDDay(LocalDate.now())),
                 PetPlantMapper.toReminderResponse(petPlant1, petPlant1.calculateDDay(LocalDate.now())),

--- a/backend/pium/src/test/java/com/official/pium/service/ReminderServiceTest.java
+++ b/backend/pium/src/test/java/com/official/pium/service/ReminderServiceTest.java
@@ -163,11 +163,11 @@ class ReminderServiceTest extends IntegrationTest {
 
 
         List<ReminderResponse> expected = List.of(
-                PetPlantMapper.toReminderResponse(petPlant4, petPlant4.calculateDDay(LocalDate.now())),
-                PetPlantMapper.toReminderResponse(petPlant3, petPlant3.calculateDDay(LocalDate.now())),
-                PetPlantMapper.toReminderResponse(petPlant2, petPlant2.calculateDDay(LocalDate.now())),
+                PetPlantMapper.toReminderResponse(petPlant, petPlant.calculateDDay(LocalDate.now())),
                 PetPlantMapper.toReminderResponse(petPlant1, petPlant1.calculateDDay(LocalDate.now())),
-                PetPlantMapper.toReminderResponse(petPlant, petPlant.calculateDDay(LocalDate.now()))
+                PetPlantMapper.toReminderResponse(petPlant2, petPlant2.calculateDDay(LocalDate.now())),
+                PetPlantMapper.toReminderResponse(petPlant3, petPlant3.calculateDDay(LocalDate.now())),
+                PetPlantMapper.toReminderResponse(petPlant4, petPlant4.calculateDDay(LocalDate.now()))
         );
 
         assertThat(actual.getData())


### PR DESCRIPTION
# 🔥 연관 이슈

- close #171 

# 🚀 작업 내용
리마인더 조회 시, 반려 식물의 `다음 물주기 날짜` 기준으로 오름차순 정렬하여 응답하도록 수정하였습니다.  
예시로 응답의 `nextWaterDate` 만 생각하면 아래와 같은 순서입니다.

```
2023-07-01,
2023-07-02,
2023-07-10,
2023-08-10

...

```

# 💬 리뷰 중점사항

코드 자체는 많이 변경된 사항은 없어서 전체적으로 봐주세요. 감사합니다!
