### PR TITLE
refactor: 내비게이션 바 리팩터링과 cypress 테스트

### DIFF
--- a/frontend/cypress/e2e/navbar.cy.ts
+++ b/frontend/cypress/e2e/navbar.cy.ts
@@ -1,0 +1,38 @@
+describe('내비게이션 바를 이용한 페이지 이동', () => {
+  beforeEach(() => {
+    cy.visit('/');
+  });
+
+  it('리마인더 페이지로 이동할 수 있다.', () => {
+    cy.get('a')
+      .contains('리마인더')
+      .click()
+      .location('pathname')
+      .should('equal', '/reminder')
+      .get('#root')
+      .should('contain', '리마인더');
+  });
+
+  it('내 반려 식물 목록 페이지로 이동할 수 있다.', () => {
+    cy.get('a')
+      .contains('내 식물')
+      .click()
+      .location('pathname')
+      .should('equal', '/pet')
+      .get('#root')
+      .should('contain', '나의 식물 카드');
+  });
+
+  it('메인 화면으로 이동할 수 있다.', () => {
+    cy.get('a')
+      .contains('리마인더')
+      .click()
+      .get('a')
+      .contains('메인')
+      .click()
+      .location('pathname')
+      .should('equal', '/')
+      .get('#root')
+      .should('contain', '식물을 쉽게');
+  });
+});

--- a/frontend/src/components/@common/Navbar/Navbar.stories.tsx
+++ b/frontend/src/components/@common/Navbar/Navbar.stories.tsx
@@ -9,6 +9,4 @@ export default meta;
 
 type Story = StoryObj<typeof Navbar>;
 
-export const Default: Story = {
-  args: {},
-};
+export const Default: Story = {};

--- a/frontend/src/components/@common/Navbar/Navbar.style.ts
+++ b/frontend/src/components/@common/Navbar/Navbar.style.ts
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 export const Wrapper = styled.nav`
-  position: sticky;
+  position: fixed;
   bottom: 0;
 
   display: flex;

--- a/frontend/src/components/@common/Navbar/index.tsx
+++ b/frontend/src/components/@common/Navbar/index.tsx
@@ -1,5 +1,4 @@
 import { useLocation } from 'react-router-dom';
-import Calendar from 'components/@common/Icons/Calendar';
 import Home from 'components/@common/Icons/Home';
 import Plant from 'components/@common/Icons/Plant';
 import Reminder from 'components/@common/Icons/Reminder';
@@ -7,30 +6,26 @@ import { NavItem, NavItemArea, NavLabel, NavLink, Wrapper } from './Navbar.style
 import { URL_PATH } from 'constants/index';
 import theme from 'style/theme.style';
 
+const navItems = [
+  {
+    path: URL_PATH.main,
+    label: '메인',
+    Icon: Home,
+  },
+  {
+    path: URL_PATH.reminder,
+    label: '리마인더',
+    Icon: Reminder,
+  },
+  {
+    path: URL_PATH.petList,
+    label: '내 식물',
+    Icon: Plant,
+  },
+];
+
 const Navbar = () => {
   const { pathname } = useLocation();
-  const navItems = [
-    {
-      path: URL_PATH.main,
-      label: '메인',
-      Icon: Home,
-    },
-    // {
-    //   path: URL_PATH.calendar,
-    //   label: '캘린더',
-    //   Icon: Calendar,
-    // },
-    {
-      path: URL_PATH.reminder,
-      label: '리마인더',
-      Icon: Reminder,
-    },
-    {
-      path: URL_PATH.petList,
-      label: '내 식물',
-      Icon: Plant,
-    },
-  ];
 
   return (
     <Wrapper>

--- a/frontend/src/components/petPlant/PetPlantDetail/PetPlantDetail.style.ts
+++ b/frontend/src/components/petPlant/PetPlantDetail/PetPlantDetail.style.ts
@@ -13,7 +13,7 @@ export const Wrapper = styled.main`
   row-gap: 30px;
   justify-content: center;
 
-  margin: 0 auto 48px auto;
+  margin: 0 auto 100px auto;
 `;
 
 export const Content = styled.div`

--- a/frontend/src/pages/DictionaryDetail/DictionaryDetail.style.ts
+++ b/frontend/src/pages/DictionaryDetail/DictionaryDetail.style.ts
@@ -4,7 +4,7 @@ export const Wrapper = styled.section`
   display: flex;
   flex-direction: column;
   gap: 24px;
-  margin: 0 auto 48px auto;
+  margin: 0 auto 100px auto;
 `;
 
 export const HeaderBox = styled.section`


### PR DESCRIPTION
# 🔥 연관 이슈

- close #226 
- close #200 
- close #203 

# 🚀 작업 내용

- navbar position fixed로 변경
    - 반려 식물 상세 정보 하단 margin 추가
    - 식물 사전 정보 하단 margin 추가
- 주석처리했던 달력 관련 이동 로직 제거
- 페이지 이동 기능 e2e 테스트 작성

# 💬 리뷰 중점사항
