### PR TITLE
feat: 반려 식물 삭제 기능 구현

### DIFF
--- a/backend/pium/src/main/java/com/official/pium/controller/PetPlantController.java
+++ b/backend/pium/src/main/java/com/official/pium/controller/PetPlantController.java
@@ -64,7 +64,7 @@ public class PetPlantController {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<PetPlantResponse> delete(
+    public ResponseEntity<Void> delete(
             @PathVariable @Positive(message = "반려 식물 ID는 1이상의 값이어야 합니다.") Long id,
             @Auth Member member) {
         petPlantService.delete(id, member);

--- a/backend/pium/src/main/java/com/official/pium/controller/PetPlantController.java
+++ b/backend/pium/src/main/java/com/official/pium/controller/PetPlantController.java
@@ -62,4 +62,12 @@ public class PetPlantController {
         petPlantService.update(id, petPlantUpdateRequest, member);
         return ResponseEntity.ok().build();
     }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<PetPlantResponse> delete(
+            @PathVariable @Positive(message = "반려 식물 ID는 1이상의 값이어야 합니다.") Long id,
+            @Auth Member member) {
+        petPlantService.delete(id, member);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/backend/pium/src/main/java/com/official/pium/controller/PetPlantController.java
+++ b/backend/pium/src/main/java/com/official/pium/controller/PetPlantController.java
@@ -15,6 +15,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;

--- a/backend/pium/src/main/java/com/official/pium/repository/HistoryRepository.java
+++ b/backend/pium/src/main/java/com/official/pium/repository/HistoryRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface HistoryRepository extends JpaRepository<History, Long> {
 
     Page<History> findAllByPetPlantId(Long petPlantId, Pageable pageable);
+
+    void deleteAllByPetPlantId(Long petPlantId);
 }

--- a/backend/pium/src/main/java/com/official/pium/service/PetPlantService.java
+++ b/backend/pium/src/main/java/com/official/pium/service/PetPlantService.java
@@ -5,6 +5,7 @@ import com.official.pium.domain.Member;
 import com.official.pium.domain.PetPlant;
 import com.official.pium.mapper.PetPlantMapper;
 import com.official.pium.repository.DictionaryPlantRepository;
+import com.official.pium.repository.HistoryRepository;
 import com.official.pium.repository.PetPlantRepository;
 import com.official.pium.service.dto.DataResponse;
 import com.official.pium.service.dto.PetPlantCreateRequest;
@@ -25,6 +26,7 @@ public class PetPlantService {
 
     private final PetPlantRepository petPlantRepository;
     private final DictionaryPlantRepository dictionaryPlantRepository;
+    private final HistoryRepository historyRepository;
 
     @Transactional
     public PetPlantResponse create(PetPlantCreateRequest request, Member member) {
@@ -77,6 +79,17 @@ public class PetPlantService {
                 updateRequest.getWind(), updateRequest.getWaterCycle(),
                 updateRequest.getBirthDate(), updateRequest.getLastWaterDate()
         );
+    }
+
+    @Transactional
+    public void delete(Long id, Member member) {
+        PetPlant petPlant = petPlantRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("일치하는 반려 식물이 존재하지 않습니다. id: " + id));
+
+        checkOwner(petPlant, member);
+
+        historyRepository.deleteAllByPetPlantId(petPlant.getId());
+        petPlantRepository.delete(petPlant);
     }
 
     private void checkOwner(PetPlant petPlant, Member member) {

--- a/backend/pium/src/main/java/com/official/pium/service/PetPlantService.java
+++ b/backend/pium/src/main/java/com/official/pium/service/PetPlantService.java
@@ -89,7 +89,7 @@ public class PetPlantService {
         checkOwner(petPlant, member);
 
         historyRepository.deleteAllByPetPlantId(petPlant.getId());
-        petPlantRepository.delete(petPlant);
+        petPlantRepository.deleteById(petPlant.getId());
     }
 
     private void checkOwner(PetPlant petPlant, Member member) {

--- a/backend/pium/src/main/resources/sql/schema.sql
+++ b/backend/pium/src/main/resources/sql/schema.sql
@@ -68,7 +68,7 @@ create TABLE IF NOT EXISTS history
 create TABLE IF NOT EXISTS history_category
 (
     id           BIGINT AUTO_INCREMENT NOT NULL,
-    category_type VARCHAR(255)         NOT NULL,
+    history_type VARCHAR(255)         NOT NULL,
     created_at   DATETIME              NOT NULL,
     updated_at   DATETIME              NOT NULL,
     CONSTRAINT pk_history_category PRIMARY KEY (id)
@@ -88,5 +88,4 @@ alter table history
 alter table history
     add CONSTRAINT FK_HISTORY_ON_HISTORY_CATEGORY FOREIGN KEY (history_category_id) REFERENCES history_category (id);
 
-alter table member
-    modify column CONSTRAINT UQ_KAKAO_ID UNIQUE (kakao_id);
+ALTER TABLE member ADD UNIQUE (kakao_id);

--- a/backend/pium/src/test/java/com/official/pium/acceptance/PetPlantApiTest.java
+++ b/backend/pium/src/test/java/com/official/pium/acceptance/PetPlantApiTest.java
@@ -452,7 +452,7 @@ public class PetPlantApiTest extends AcceptanceTest {
     class 반려_식물_삭제_시_ {
 
         @Test
-        void 정상_삭제_후_204를_반환하고_조회할_수_없다() {
+        void 정상_삭제_후_204를_반환_및_조회_불가() {
             DictionaryPlant dictionaryPlant = dictionaryPlantSupport.builder().build();
             PetPlantCreateRequest request = REQUEST.generatePetPlantCreateRequest(dictionaryPlant.getId());
             Long 반려_식물_ID = 반려_식물_등록_요청(request);
@@ -518,7 +518,6 @@ public class PetPlantApiTest extends AcceptanceTest {
                     .statusCode(HttpStatus.BAD_REQUEST.value())
                     .assertThat().body("message", containsString("요청 사용자와 반려 식물의 사용자가 일치하지 않습니다."));
         }
-
     }
 
     private ExtractableResponse<Response> 반려_식물_단건_조회(Long petPlantId) {

--- a/backend/pium/src/test/java/com/official/pium/acceptance/PetPlantApiTest.java
+++ b/backend/pium/src/test/java/com/official/pium/acceptance/PetPlantApiTest.java
@@ -20,7 +20,6 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.time.LocalDate;
 import java.util.List;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
@@ -397,7 +396,7 @@ public class PetPlantApiTest extends AcceptanceTest {
 
             ExtractableResponse<Response> response = 반려_식물_단건_조회(petPlant.getId());
 
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.jsonPath().getString("nickname")).isEqualTo(request.getNickname());
                 softly.assertThat(response.jsonPath().getString("flowerpot")).isEqualTo(request.getFlowerpot());
                 softly.assertThat(response.jsonPath().getString("location")).isEqualTo(request.getLocation());
@@ -447,6 +446,79 @@ public class PetPlantApiTest extends AcceptanceTest {
                     .statusCode(HttpStatus.BAD_REQUEST.value())
                     .assertThat().body("message", containsString("반려 식물 ID는 1이상의 값이어야 합니다."));
         }
+    }
+
+    @Nested
+    class 반려_식물_삭제_시_ {
+
+        @Test
+        void 정상_삭제_후_204를_반환하고_조회할_수_없다() {
+            DictionaryPlant dictionaryPlant = dictionaryPlantSupport.builder().build();
+            PetPlantCreateRequest request = REQUEST.generatePetPlantCreateRequest(dictionaryPlant.getId());
+            Long 반려_식물_ID = 반려_식물_등록_요청(request);
+
+            RestAssured
+                    .given()
+                    .log().all()
+                    .header("Authorization", member.getEmail())
+                    .delete("/pet-plants/{id}", 반려_식물_ID)
+                    .then()
+                    .log().all()
+                    .statusCode(HttpStatus.NO_CONTENT.value());
+
+            RestAssured
+                    .given()
+                    .log().all()
+                    .header("Authorization", member.getEmail())
+                    .get("/pet-plants/{id}", 반려_식물_ID)
+                    .then()
+                    .log().all()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .assertThat().body("message", containsString("일치하는 반려 식물이 존재하지 않습니다. id: " + 반려_식물_ID));
+        }
+
+        @Test
+        void 존재하지_않는_사용자라면_404_반환() {
+            DictionaryPlant dictionaryPlant = dictionaryPlantSupport.builder().build();
+            PetPlant petPlant = petPlantSupport.builder()
+                    .dictionaryPlant(dictionaryPlant)
+                    .build();
+
+            RestAssured
+                    .given()
+                    .log().all()
+                    .header("Authorization", "invalidMember")
+                    .when()
+                    .delete("/pet-plants/{id}", petPlant.getId())
+                    .then()
+                    .log().all()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .assertThat().body("message", containsString("회원을 찾을 수 없습니다."));
+        }
+
+        @Test
+        void 본인의_반려_식물이_아니라면_400_반환() {
+            DictionaryPlant dictionaryPlant = dictionaryPlantSupport.builder().build();
+            PetPlant petPlant = petPlantSupport.builder()
+                    .member(member)
+                    .dictionaryPlant(dictionaryPlant)
+                    .build();
+            Member other = memberSupport.builder()
+                    .email("otherMember@gmail.com")
+                    .build();
+
+            RestAssured
+                    .given()
+                    .log().all()
+                    .header("Authorization", other.getEmail())
+                    .when()
+                    .delete("/pet-plants/{id}", petPlant.getId())
+                    .then()
+                    .log().all()
+                    .statusCode(HttpStatus.BAD_REQUEST.value())
+                    .assertThat().body("message", containsString("요청 사용자와 반려 식물의 사용자가 일치하지 않습니다."));
+        }
+
     }
 
     private ExtractableResponse<Response> 반려_식물_단건_조회(Long petPlantId) {

--- a/backend/pium/src/test/java/com/official/pium/config/DatabaseCleaner.java
+++ b/backend/pium/src/test/java/com/official/pium/config/DatabaseCleaner.java
@@ -1,6 +1,5 @@
 package com.official.pium.config;
 
-import jakarta.annotation.PostConstruct;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.util.ArrayList;
@@ -17,7 +16,6 @@ public class DatabaseCleaner {
     private EntityManager entityManager;
 
     @SuppressWarnings("unchecked")
-    @PostConstruct
     private void findDatabaseTableNames() {
         List<Object[]> tableInfos = entityManager.createNativeQuery("SHOW TABLES").getResultList();
         for (Object[] tableInfo : tableInfos) {
@@ -36,6 +34,7 @@ public class DatabaseCleaner {
 
     @Transactional
     public void clear() {
+        findDatabaseTableNames();
         entityManager.clear();
         truncate();
     }

--- a/backend/pium/src/test/java/com/official/pium/controller/PetPlantControllerTest.java
+++ b/backend/pium/src/test/java/com/official/pium/controller/PetPlantControllerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -379,6 +380,33 @@ class PetPlantControllerTest extends UITest {
                     .andDo(print())
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.message").value(containsString("마지막 물주기 날짜는 필수 값입니다.")))
+                    .andDo(print());
+        }
+    }
+
+    @Nested
+    class 반려_식물_삭제_ {
+
+        @Test
+        void 정상_요청시_200_반환() throws Exception {
+            willDoNothing().given(petPlantService)
+                    .delete(anyLong(), any(Member.class));
+
+            mockMvc.perform(delete("/pet-plants/{id}", 1L)
+                            .header("Authorization", "pium@gmail.com"))
+                    .andExpect(status().isNoContent())
+                    .andDo(print());
+        }
+
+        @Test
+        void 잘못된_ID로_삭제하면_400을_반환() throws Exception {
+            Long wrongId = -1L;
+
+            mockMvc.perform(delete("/pet-plants/{id}", wrongId)
+                            .header("Authorization", "pium@gmail.com"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value(containsString("반려 식물 ID는 1이상의 값이어야 합니다.")))
                     .andDo(print());
         }
     }

--- a/backend/pium/src/test/java/com/official/pium/controller/PetPlantControllerTest.java
+++ b/backend/pium/src/test/java/com/official/pium/controller/PetPlantControllerTest.java
@@ -152,7 +152,6 @@ class PetPlantControllerTest extends UITest {
                             .content(objectMapper.writeValueAsString(피우미_수정_요청))
                             .contentType(MediaType.APPLICATION_JSON)
                             .characterEncoding(StandardCharsets.UTF_8))
-                    .andDo(print())
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.message").value(containsString("반려 식물 ID는 1이상의 값이어야 합니다.")))
                     .andDo(print());
@@ -203,7 +202,6 @@ class PetPlantControllerTest extends UITest {
                             .content(objectMapper.writeValueAsString(updateRequest))
                             .contentType(MediaType.APPLICATION_JSON)
                             .characterEncoding(StandardCharsets.UTF_8))
-                    .andDo(print())
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.message").value(containsString("화분 정보는 필수 값입니다.")))
                     .andDo(print());
@@ -229,7 +227,6 @@ class PetPlantControllerTest extends UITest {
                             .content(objectMapper.writeValueAsString(updateRequest))
                             .contentType(MediaType.APPLICATION_JSON)
                             .characterEncoding(StandardCharsets.UTF_8))
-                    .andDo(print())
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.message").value(containsString("화분 위치는 필수 값입니다.")))
                     .andDo(print());
@@ -253,7 +250,6 @@ class PetPlantControllerTest extends UITest {
                             .content(objectMapper.writeValueAsString(updateRequest))
                             .contentType(MediaType.APPLICATION_JSON)
                             .characterEncoding(StandardCharsets.UTF_8))
-                    .andDo(print())
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.message").value(containsString("물주기 주기 값은 필수 값입니다.")))
                     .andDo(print());
@@ -277,7 +273,6 @@ class PetPlantControllerTest extends UITest {
                             .content(objectMapper.writeValueAsString(updateRequest))
                             .contentType(MediaType.APPLICATION_JSON)
                             .characterEncoding(StandardCharsets.UTF_8))
-                    .andDo(print())
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.message").value(containsString("물주기 주기 값은 양수만 가능합니다.")))
                     .andDo(print());
@@ -303,7 +298,6 @@ class PetPlantControllerTest extends UITest {
                             .content(objectMapper.writeValueAsString(updateRequest))
                             .contentType(MediaType.APPLICATION_JSON)
                             .characterEncoding(StandardCharsets.UTF_8))
-                    .andDo(print())
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.message").value(containsString("조도 정보는 필수 값입니다.")))
                     .andDo(print());
@@ -329,7 +323,6 @@ class PetPlantControllerTest extends UITest {
                             .content(objectMapper.writeValueAsString(updateRequest))
                             .contentType(MediaType.APPLICATION_JSON)
                             .characterEncoding(StandardCharsets.UTF_8))
-                    .andDo(print())
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.message").value(containsString("통풍 정보는 필수 값입니다.")))
                     .andDo(print());
@@ -353,7 +346,6 @@ class PetPlantControllerTest extends UITest {
                             .content(objectMapper.writeValueAsString(updateRequest))
                             .contentType(MediaType.APPLICATION_JSON)
                             .characterEncoding(StandardCharsets.UTF_8))
-                    .andDo(print())
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.message").value(containsString("반려 식물 입양일은 필수 값입니다.")))
                     .andDo(print());
@@ -377,7 +369,6 @@ class PetPlantControllerTest extends UITest {
                             .content(objectMapper.writeValueAsString(updateRequest))
                             .contentType(MediaType.APPLICATION_JSON)
                             .characterEncoding(StandardCharsets.UTF_8))
-                    .andDo(print())
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.message").value(containsString("마지막 물주기 날짜는 필수 값입니다.")))
                     .andDo(print());
@@ -404,7 +395,6 @@ class PetPlantControllerTest extends UITest {
 
             mockMvc.perform(delete("/pet-plants/{id}", wrongId)
                             .header("Authorization", "pium@gmail.com"))
-                    .andDo(print())
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.message").value(containsString("반려 식물 ID는 1이상의 값이어야 합니다.")))
                     .andDo(print());

--- a/backend/pium/src/test/java/com/official/pium/domain/PetPlantTest.java
+++ b/backend/pium/src/test/java/com/official/pium/domain/PetPlantTest.java
@@ -2,7 +2,7 @@ package com.official.pium.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.official.pium.fixture.MemberFixture;
 import com.official.pium.fixture.PetPlantFixture;
@@ -70,13 +70,15 @@ class PetPlantTest {
             petPlant.updatePetPlant("기철이", "책상", "수경 재배", "거의 없음",
                     "통풍이 잘 됨", 10, LocalDate.of(2022, 7, 1), LocalDate.of(2022, 7, 8));
 
-            assertAll(
-                    () -> assertThat(petPlant.getNickname()).isEqualTo("기철이"),
-                    () -> assertThat(petPlant.getLocation()).isEqualTo("책상"),
-                    () -> assertThat(petPlant.getFlowerpot()).isEqualTo("수경 재배"),
-                    () -> assertThat(petPlant.getLight()).isEqualTo("거의 없음"),
-                    () -> assertThat(petPlant.getWind()).isEqualTo("통풍이 잘 됨"),
-                    () -> assertThat(petPlant.getWaterCycle()).isEqualTo(10)
+            assertSoftly(
+                    softly -> {
+                        softly.assertThat(petPlant.getNickname()).isEqualTo("기철이");
+                        softly.assertThat(petPlant.getLocation()).isEqualTo("책상");
+                        softly.assertThat(petPlant.getFlowerpot()).isEqualTo("수경 재배");
+                        softly.assertThat(petPlant.getLight()).isEqualTo("거의 없음");
+                        softly.assertThat(petPlant.getWind()).isEqualTo("통풍이 잘 됨");
+                        softly.assertThat(petPlant.getWaterCycle()).isEqualTo(10);
+                    }
             );
         }
 

--- a/backend/pium/src/test/java/com/official/pium/repository/MemberRepositoryTest.java
+++ b/backend/pium/src/test/java/com/official/pium/repository/MemberRepositoryTest.java
@@ -1,7 +1,7 @@
 package com.official.pium.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.official.pium.RepositoryTest;
 import com.official.pium.domain.Member;
@@ -25,9 +25,11 @@ class MemberRepositoryTest extends RepositoryTest {
 
         Member save = memberRepository.save(member);
 
-        assertAll(
-                () -> assertThat(save).isNotNull(),
-                () -> assertThat(save.getId()).isEqualTo(member.getId())
+        assertSoftly(
+                softly -> {
+                    softly.assertThat(save).isNotNull();
+                    softly.assertThat(save.getId()).isEqualTo(member.getId());
+                }
         );
     }
 

--- a/backend/pium/src/test/java/com/official/pium/repository/MemberRepositoryTest.java
+++ b/backend/pium/src/test/java/com/official/pium/repository/MemberRepositoryTest.java
@@ -37,8 +37,8 @@ class MemberRepositoryTest extends RepositoryTest {
     void 사용자_조회() {
         Member member = Member.builder().email("hello@aaa.com").build();
 
-        Member save = memberRepository.save(member);
+        Member saveMember = memberRepository.save(member);
 
-        assertThat(memberRepository.findById(save.getId())).isPresent();
+        assertThat(memberRepository.findById(saveMember.getId())).isPresent();
     }
 }

--- a/backend/pium/src/test/java/com/official/pium/repository/PetPlantRepositoryTest.java
+++ b/backend/pium/src/test/java/com/official/pium/repository/PetPlantRepositoryTest.java
@@ -1,7 +1,7 @@
 package com.official.pium.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.official.pium.RepositoryTest;
 import com.official.pium.domain.DictionaryPlant;
@@ -43,9 +43,11 @@ class PetPlantRepositoryTest extends RepositoryTest {
 
         PetPlant savePetPlant = petPlantRepository.save(petPlant);
 
-        assertAll(
-                () -> assertThat(savePetPlant).isNotNull(),
-                () -> assertThat(savePetPlant.getId()).isEqualTo(petPlant.getId())
+        assertSoftly(
+                softly -> {
+                    softly.assertThat(savePetPlant).isNotNull();
+                    softly.assertThat(savePetPlant.getId()).isEqualTo(petPlant.getId());
+                }
         );
     }
 

--- a/backend/pium/src/test/java/com/official/pium/repository/PetPlantRepositoryTest.java
+++ b/backend/pium/src/test/java/com/official/pium/repository/PetPlantRepositoryTest.java
@@ -39,20 +39,7 @@ class PetPlantRepositoryTest extends RepositoryTest {
 
     @Test
     void 반려_식물_저장() {
-        PetPlant petPlant = PetPlant.builder()
-                .dictionaryPlant(dictionaryPlant)
-                .member(member)
-                .nickname("피우미")
-                .imageUrl("https://image.com")
-                .location("베란다")
-                .flowerpot("화분")
-                .light("밝아요")
-                .wind("추워요")
-                .birthDate(LocalDate.now())
-                .nextWaterDate(LocalDate.now())
-                .lastWaterDate(LocalDate.now())
-                .waterCycle(3)
-                .build();
+        PetPlant petPlant = createPetPlant();
 
         PetPlant savePetPlant = petPlantRepository.save(petPlant);
 
@@ -64,7 +51,25 @@ class PetPlantRepositoryTest extends RepositoryTest {
 
     @Test
     void 반려_식물_조회() {
-        PetPlant petPlant = PetPlant.builder()
+        PetPlant petPlant = createPetPlant();
+
+        PetPlant savePetPlant = petPlantRepository.save(petPlant);
+
+        assertThat(petPlantRepository.findById(savePetPlant.getId())).isPresent();
+    }
+
+    @Test
+    void 반려_식물_삭제() {
+        PetPlant petPlant = createPetPlant();
+        petPlantRepository.save(petPlant);
+
+        petPlantRepository.delete(petPlant);
+
+        assertThat(petPlantRepository.findById(petPlant.getId())).isEmpty();
+    }
+
+    private PetPlant createPetPlant() {
+        return PetPlant.builder()
                 .dictionaryPlant(dictionaryPlant)
                 .member(member)
                 .nickname("피우미")
@@ -78,9 +83,5 @@ class PetPlantRepositoryTest extends RepositoryTest {
                 .lastWaterDate(LocalDate.now())
                 .waterCycle(3)
                 .build();
-
-        PetPlant savePetPlant = petPlantRepository.save(petPlant);
-
-        assertThat(petPlantRepository.findById(savePetPlant.getId())).isPresent();
     }
 }

--- a/backend/pium/src/test/java/com/official/pium/service/DictionaryPlantServiceTest.java
+++ b/backend/pium/src/test/java/com/official/pium/service/DictionaryPlantServiceTest.java
@@ -3,7 +3,7 @@ package com.official.pium.service;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.official.pium.IntegrationTest;
 import com.official.pium.domain.DictionaryPlant;
@@ -54,10 +54,12 @@ class DictionaryPlantServiceTest extends IntegrationTest {
         DataResponse<List<DictionaryPlantSearchResponse>> searchResultsContainsParamName = dictionaryPlantService.search(
                 "스투");
 
-        assertAll(
-                () -> assertThat(searchResultsContainsParamName.getData()).hasSize(2),
-                () -> assertThat(searchResultsContainsParamName.getData().get(0).getId()).isEqualTo(스투키1.getId()),
-                () -> assertThat(searchResultsContainsParamName.getData().get(1).getId()).isEqualTo(스투키2.getId())
+        assertSoftly(
+                softly -> {
+                    softly.assertThat(searchResultsContainsParamName.getData()).hasSize(2);
+                    softly.assertThat(searchResultsContainsParamName.getData().get(0).getId()).isEqualTo(스투키1.getId());
+                    softly.assertThat(searchResultsContainsParamName.getData().get(1).getId()).isEqualTo(스투키2.getId());
+                }
         );
     }
 

--- a/backend/pium/src/test/java/com/official/pium/service/PetPlantServiceTest.java
+++ b/backend/pium/src/test/java/com/official/pium/service/PetPlantServiceTest.java
@@ -1,5 +1,7 @@
 package com.official.pium.service;
 
+import static com.official.pium.fixture.PetPlantFixture.REQUEST.피우미_등록_요청;
+import static com.official.pium.fixture.PetPlantFixture.REQUEST.피우미_수정_요청;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
@@ -51,17 +53,7 @@ class PetPlantServiceTest extends IntegrationTest {
 
     @Test
     void 반려_식물_등록() {
-        PetPlantCreateRequest request = PetPlantCreateRequest.builder()
-                .dictionaryPlantId(dictionaryPlant.getId())
-                .nickname("피우미")
-                .location("베란다")
-                .flowerpot("플라스틱 화분")
-                .waterCycle(3)
-                .light("빛 많이 필요함")
-                .wind("바람이 잘 통하는 곳")
-                .birthDate(LocalDate.now())
-                .lastWaterDate(LocalDate.now())
-                .build();
+        PetPlantCreateRequest request = 피우미_등록_요청;
 
         PetPlantResponse petPlantResponse = petPlantService.create(request, member);
 
@@ -132,16 +124,7 @@ class PetPlantServiceTest extends IntegrationTest {
     @Test
     void 반려_식물_정보_수정() {
         PetPlant petPlant = petPlantSupport.builder().member(member).build();
-        PetPlantUpdateRequest updateRequest = PetPlantUpdateRequest.builder()
-                .nickname("피우미 2")
-                .location("침대 옆")
-                .flowerpot("유리병")
-                .waterCycle(10)
-                .light("빛 많이 필요함")
-                .wind("바람이 잘 통하는 곳")
-                .birthDate(LocalDate.now())
-                .lastWaterDate(LocalDate.now())
-                .build();
+        PetPlantUpdateRequest updateRequest = 피우미_수정_요청;
 
         petPlantService.update(petPlant.getId(), updateRequest, member);
         PetPlant updatedPetPlant = petPlantRepository.findById(petPlant.getId()).get();
@@ -164,16 +147,7 @@ class PetPlantServiceTest extends IntegrationTest {
     void 반려_식물_수정시_주인이_아니면_예외_발생() {
         Member otherMember = memberSupport.builder().build();
         PetPlant petPlant = petPlantSupport.builder().member(member).build();
-        PetPlantUpdateRequest updateRequest = PetPlantUpdateRequest.builder()
-                .nickname("피우미 2")
-                .location("침대 옆")
-                .flowerpot("유리병")
-                .waterCycle(10)
-                .light("빛 많이 필요함")
-                .wind("바람이 잘 통하는 곳")
-                .birthDate(LocalDate.now())
-                .lastWaterDate(LocalDate.now())
-                .build();
+        PetPlantUpdateRequest updateRequest = 피우미_수정_요청;
 
         assertThatThrownBy(() -> petPlantService.update(petPlant.getId(), updateRequest, otherMember))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -183,16 +157,7 @@ class PetPlantServiceTest extends IntegrationTest {
     @Test
     void 존재하지_않는_반려_식물을_수정하면_예외_발생() {
         Long wrongId = -1L;
-        PetPlantUpdateRequest updateRequest = PetPlantUpdateRequest.builder()
-                .nickname("피우미 2")
-                .location("침대 옆")
-                .flowerpot("유리병")
-                .waterCycle(10)
-                .light("빛 많이 필요함")
-                .wind("바람이 잘 통하는 곳")
-                .birthDate(LocalDate.now())
-                .lastWaterDate(LocalDate.now())
-                .build();
+        PetPlantUpdateRequest updateRequest = 피우미_수정_요청;
 
         assertThatThrownBy(() -> petPlantService.update(wrongId, updateRequest, member))
                 .isInstanceOf(NoSuchElementException.class)
@@ -218,7 +183,8 @@ class PetPlantServiceTest extends IntegrationTest {
         assertSoftly(
                 softly -> {
                     softly.assertThat(petPlantRepository.findById(petPlant.getId())).isEmpty();
-                    softly.assertThat(historyRepository.findAllByPetPlantId(petPlant.getId(), pageRequest).getContent()).isEmpty();
+                    softly.assertThat(historyRepository.findAllByPetPlantId(petPlant.getId(), pageRequest).getContent())
+                            .isEmpty();
                 }
         );
     }

--- a/backend/pium/src/test/java/com/official/pium/service/PetPlantServiceTest.java
+++ b/backend/pium/src/test/java/com/official/pium/service/PetPlantServiceTest.java
@@ -1,6 +1,5 @@
 package com.official.pium.service;
 
-import static com.official.pium.fixture.PetPlantFixture.REQUEST.피우미_등록_요청;
 import static com.official.pium.fixture.PetPlantFixture.REQUEST.피우미_수정_요청;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -53,7 +52,17 @@ class PetPlantServiceTest extends IntegrationTest {
 
     @Test
     void 반려_식물_등록() {
-        PetPlantCreateRequest request = 피우미_등록_요청;
+        PetPlantCreateRequest request = PetPlantCreateRequest.builder()
+                .dictionaryPlantId(dictionaryPlant.getId())
+                .nickname("피우미")
+                .location("베란다")
+                .flowerpot("플라스틱 화분")
+                .waterCycle(3)
+                .light("빛 많이 필요함")
+                .wind("바람이 잘 통하는 곳")
+                .birthDate(LocalDate.now())
+                .lastWaterDate(LocalDate.now())
+                .build();
 
         PetPlantResponse petPlantResponse = petPlantService.create(request, member);
 


### PR DESCRIPTION
# 🔥 연관 이슈

- close #220 

# 🚀 작업 내용

- [x] 반려 식물 삭제 기능 구현
- [x] 삭제되는 반려 식물에 연관된 히스토리 삭제

# 💬 리뷰 중점사항

반려 식물 삭제 기능을 구현했습니다 !

- 수정과 마찬가지로 반려 식물의 주인을 확인하는 로직을 추가했습니다.
- 현재 구현하는 `반려 식물 삭제`는 무덤과는 관계없이 완전히 서비스에서 삭제하므로, `관련 히스토리까지 삭제`하도록 구현했습니다.
- 삭제 기능의 인수 테스트를 명확히 하기 애매했던 것 같아요 🥹 그래서 `등록 -> 삭제 -> 조회 시 없음`의 과정을 인수 테스트로 작성했습니다. 관련해서 의견 남겨주시면 좋을 것 같아요 :)
