### PR TITLE
refactor: 달력, 모달, 그리고 DateFormat

### DIFF
--- a/frontend/src/components/@common/Calendar/Calendar.style.ts
+++ b/frontend/src/components/@common/Calendar/Calendar.style.ts
@@ -50,3 +50,9 @@ export const AlertSpan = styled.span`
   clip-path: inset(50%);
   border: 0;
 `;
+
+export const Button = styled.button`
+  &:disabled {
+    cursor: default;
+  }
+`;

--- a/frontend/src/components/@common/Calendar/DaySmallBox/DaySmallBox.style.ts
+++ b/frontend/src/components/@common/Calendar/DaySmallBox/DaySmallBox.style.ts
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
 
 interface DayProps {
-  isToday: boolean | null;
-  isInRange: boolean;
+  $isToday: boolean | null;
+  $isInRange: boolean;
 }
 
 export const Wrapper = styled.div`
@@ -20,25 +20,25 @@ export const DaySpan = styled.span<DayProps>`
   width: 40px;
   height: 40px;
 
-  color: ${({ isToday, isInRange, theme: { color } }) => {
-    if (isToday) return color.background;
-    if (isInRange) return color.sub;
+  color: ${({ $isToday, $isInRange, theme: { color } }) => {
+    if ($isToday) return color.background;
+    if ($isInRange) return color.sub;
     return color.grayDark;
   }};
 
-  background: ${({ isToday, isInRange, theme: { color } }) => {
-    if (isToday && isInRange) return color.accent;
-    if (isToday) return color.accent + '5F';
+  background: ${({ $isToday, $isInRange, theme: { color } }) => {
+    if ($isToday && $isInRange) return color.accent;
+    if ($isToday) return color.accent + '5F';
     return color.background;
   }};
   border-radius: 50%;
 
   &:hover {
-    color: ${({ isToday, isInRange, theme: { color } }) =>
-      isToday || isInRange ? color.background : color.grayDark};
-    background: ${({ isToday, isInRange, theme: { color } }) => {
-      if (isToday && !isInRange) return color.accent + '5F';
-      if (!isToday && !isInRange) return color.background;
+    color: ${({ $isToday, $isInRange, theme: { color } }) =>
+      $isToday || $isInRange ? color.background : color.grayDark};
+    background: ${({ $isToday, $isInRange, theme: { color } }) => {
+      if ($isToday && !$isInRange) return color.accent + '5F';
+      if (!$isToday && !$isInRange) return color.background;
       return color.accent;
     }};
   }

--- a/frontend/src/components/@common/Calendar/DaySmallBox/DaySmallBox.style.ts
+++ b/frontend/src/components/@common/Calendar/DaySmallBox/DaySmallBox.style.ts
@@ -20,9 +20,26 @@ export const DaySpan = styled.span<DayProps>`
   width: 40px;
   height: 40px;
 
-  color: ${({ isToday, isInRange, theme: { color } }) =>
-    isToday ? color.background : isInRange ? color.sub : color.grayDark};
+  color: ${({ isToday, isInRange, theme: { color } }) => {
+    if (isToday) return color.background;
+    if (isInRange) return color.sub;
+    return color.grayDark;
+  }};
 
-  background: ${({ isToday, theme: { color } }) => (isToday ? color.accent : color.background)};
+  background: ${({ isToday, isInRange, theme: { color } }) => {
+    if (isToday && isInRange) return color.accent;
+    if (isToday) return color.accent + '5F';
+    return color.background;
+  }};
   border-radius: 50%;
+
+  &:hover {
+    color: ${({ isToday, isInRange, theme: { color } }) =>
+      isToday || isInRange ? color.background : color.grayDark};
+    background: ${({ isToday, isInRange, theme: { color } }) => {
+      if (isToday && !isInRange) return color.accent + '5F';
+      if (!isToday && !isInRange) return color.background;
+      return color.accent;
+    }};
+  }
 `;

--- a/frontend/src/components/@common/Calendar/DaySmallBox/DaySmallBox.style.ts
+++ b/frontend/src/components/@common/Calendar/DaySmallBox/DaySmallBox.style.ts
@@ -11,7 +11,7 @@ export const Wrapper = styled.div`
 `;
 
 export const DaySpan = styled.span<DayProps>`
-  cursor: pointer;
+  cursor: ${({ $isInRange }) => $isInRange ? 'pointer' : 'default'};
 
   display: flex;
   align-items: center;

--- a/frontend/src/components/@common/Calendar/DaySmallBox/index.tsx
+++ b/frontend/src/components/@common/Calendar/DaySmallBox/index.tsx
@@ -28,11 +28,11 @@ const DaySmallBox = ({
     <Wrapper>
       {date && (
         <DaySpan
-          isToday={isToday ?? null}
+          $isToday={isToday ?? null}
           role={clickHandler ? 'button' : 'none'}
           onClick={clickHandler}
           aria-label={ariaLabel}
-          isInRange={isInRange}
+          $isInRange={isInRange}
           tabIndex={clickHandler && 0}
           onKeyDown={keyDownHandler}
         >

--- a/frontend/src/components/@common/Calendar/index.tsx
+++ b/frontend/src/components/@common/Calendar/index.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
-import { AlertSpan, CalendarBox, DaysBox, HeaderBox, Wrapper } from './Calendar.style';
+import { AlertSpan, Button, CalendarBox, DaysBox, HeaderBox, Wrapper } from './Calendar.style';
 import useCalendar from 'hooks/useCalendar';
 import { convertDateKorYear, getDateToString, getDayInfo } from 'utils/date';
+import { dateValidate } from 'utils/validate';
 import { DAYS_OF_THE_WEEK } from 'constants/index';
 import ArrowLeft from '../Icons/ArrowLeft';
 import ArrowRight from '../Icons/ArrowRight';
@@ -14,7 +15,9 @@ interface CalendarProps {
   min?: React.InputHTMLAttributes<HTMLInputElement>['min'];
 }
 
-const Calendar = ({ currentDate, min, max, dateCallback }: CalendarProps) => {
+const Calendar = (props: CalendarProps) => {
+  const { currentDate, min = '1945/08/15', max = '2222/02/22', dateCallback } = props;
+
   const { monthInfo, setPrevMonth, setNextMonth } = useCalendar(currentDate);
   const { year, month, monthFirstDay, monthLastDate } = monthInfo;
   const boxLength = monthFirstDay + monthLastDate <= 35 ? 35 : 42;
@@ -50,17 +53,37 @@ const Calendar = ({ currentDate, min, max, dateCallback }: CalendarProps) => {
   });
 
   const yearMonth = `${year}년 ${month}월`;
+  const isPrevMonthOutOfRange = !dateValidate.isDateInRange({
+    dateToCheck: new Date(Number(year), Number(month) - 2, 28),
+    startDate: new Date(min),
+    endDate: new Date(max),
+  });
+  const isNextMonthOutOfRange = !dateValidate.isDateInRange({
+    dateToCheck: new Date(Number(year), Number(month), 1),
+    startDate: new Date(min),
+    endDate: new Date(max),
+  });
 
   return (
     <Wrapper role="application" aria-label="달력" aria-roledescription="calendar">
       <HeaderBox role="group">
-        <button type="button" onClick={setPrevMonth} aria-label="이전 달 보기">
-          <ArrowLeft width={28} height={28} />
-        </button>
+        <Button
+          type="button"
+          onClick={setPrevMonth}
+          aria-label="이전 달 보기"
+          disabled={isPrevMonthOutOfRange}
+        >
+          <ArrowLeft width={32} height={32} opacity={isPrevMonthOutOfRange ? '10%' : '100%'} />
+        </Button>
         <p role="alert">{yearMonth}</p>
-        <button type="button" onClick={setNextMonth} aria-label="다음 달 보기">
-          <ArrowRight width={28} height={28} />
-        </button>
+        <Button
+          type="button"
+          onClick={setNextMonth}
+          aria-label="다음 달 보기"
+          disabled={isNextMonthOutOfRange}
+        >
+          <ArrowRight width={32} height={32} opacity={isNextMonthOutOfRange ? '10%' : '100%'} />
+        </Button>
       </HeaderBox>
       <DaysBox aria-hidden="true">{daysOfWeeks}</DaysBox>
       <CalendarBox aria-live="assertive">{days}</CalendarBox>

--- a/frontend/src/components/@common/Calendar/index.tsx
+++ b/frontend/src/components/@common/Calendar/index.tsx
@@ -16,7 +16,7 @@ interface CalendarProps {
 }
 
 const Calendar = (props: CalendarProps) => {
-  const { currentDate, min = '1945/08/15', max = '2222/02/22', dateCallback } = props;
+  const { currentDate, min = '1945/08/15', max = '2099/12/31', dateCallback } = props;
 
   const { monthInfo, setPrevMonth, setNextMonth } = useCalendar(currentDate);
   const { year, month, monthFirstDay, monthLastDate } = monthInfo;

--- a/frontend/src/components/@common/Calendar/index.tsx
+++ b/frontend/src/components/@common/Calendar/index.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { AlertSpan, Button, CalendarBox, DaysBox, HeaderBox, Wrapper } from './Calendar.style';
 import useCalendar from 'hooks/useCalendar';
 import { convertDateKorYear, getDateToString, getDayInfo } from 'utils/date';
-import { dateValidate } from 'utils/validate';
+import { DateValidate } from 'utils/validate';
 import { DAYS_OF_THE_WEEK } from 'constants/index';
 import ArrowLeft from '../Icons/ArrowLeft';
 import ArrowRight from '../Icons/ArrowRight';
@@ -53,12 +53,12 @@ const Calendar = (props: CalendarProps) => {
   });
 
   const yearMonth = `${year}년 ${month}월`;
-  const isPrevMonthOutOfRange = !dateValidate.isDateInRange({
+  const isPrevMonthOutOfRange = !DateValidate.isDateInRange({
     dateToCheck: new Date(Number(year), Number(month) - 2, 28),
     startDate: new Date(min),
     endDate: new Date(max),
   });
-  const isNextMonthOutOfRange = !dateValidate.isDateInRange({
+  const isNextMonthOutOfRange = !DateValidate.isDateInRange({
     dateToCheck: new Date(Number(year), Number(month), 1),
     startDate: new Date(min),
     endDate: new Date(max),

--- a/frontend/src/components/@common/DateInput/DateInput.stories.tsx
+++ b/frontend/src/components/@common/DateInput/DateInput.stories.tsx
@@ -2,7 +2,12 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 import ToastList from 'components/@common/Toast/ToastList';
 import ToastProvider from 'contexts/toastContext';
-import { getDateToString, getParticularDateFromSpecificDay, getStringToDate } from 'utils/date';
+import {
+  getDateToString,
+  getParticularDateFromSpecificDay,
+  getStringToDate,
+  isDateFormat,
+} from 'utils/date';
 import DateInput from '.';
 
 const meta: Meta<typeof DateInput> = {
@@ -26,9 +31,9 @@ type Story = StoryObj<typeof DateInput>;
 export const Default: Story = {
   render: () => {
     const [value, setValue] = useState(getDateToString);
-    const changeHandler = (val: string) => {
-      setValue(val);
-      return true;
+    const changeHandler = (newValue: string) => {
+      if (!isDateFormat(newValue)) return;
+      setValue(newValue);
     };
     return <DateInput value={value} changeCallback={changeHandler} />;
   },
@@ -38,9 +43,9 @@ export const HasRange: Story = {
   render: () => {
     const today = getDateToString();
     const [value, setValue] = useState(today);
-    const changeHandler = (val: string) => {
-      setValue(val);
-      return true;
+    const changeHandler = (newValue: string) => {
+      if (!isDateFormat(newValue)) return;
+      setValue(newValue);
     };
 
     return (

--- a/frontend/src/components/@common/DateInput/index.tsx
+++ b/frontend/src/components/@common/DateInput/index.tsx
@@ -40,7 +40,7 @@ const DateInput = (props: DateInputProps) => {
       </DateValue>
       <Modal isOpen={isOpen} ref={modalRef} closeModal={off}>
         <Calendar
-          currentDate={getStringToDate(value === '' ? null : value)}
+          currentDate={value === '' ? new Date() : getStringToDate(value)}
           dateCallback={dateCallbackHandler}
           min={min}
           max={max}

--- a/frontend/src/components/petPlant/PetPlantCard/PetPlantCard.stories.tsx
+++ b/frontend/src/components/petPlant/PetPlantCard/PetPlantCard.stories.tsx
@@ -1,3 +1,4 @@
+import type { DateFormat } from 'types/date';
 import type { Meta, StoryObj } from '@storybook/react';
 import PetCard from '.';
 
@@ -15,7 +16,7 @@ export const Default: Story = {
     nickname: '기영이',
     imageUrl: 'https://images.unsplash.com/photo-1667342608690-828e1a839ead',
     dictionaryPlantName: '스투키',
-    birthDate: '2023-07-08',
+    birthDate: '2023-07-08' as DateFormat,
     daySince: 95,
   },
 };
@@ -26,7 +27,7 @@ export const LongText: Story = {
     nickname: '기영기영기영기영이',
     imageUrl: 'https://images.unsplash.com/photo-1667342608690-828e1a839ead',
     dictionaryPlantName: '스투스투스투스투키',
-    birthDate: '2023-07-08',
+    birthDate: '2023-07-08' as DateFormat,
     daySince: 95,
   },
 };

--- a/frontend/src/components/petPlant/PetPlantEditForm/index.tsx
+++ b/frontend/src/components/petPlant/PetPlantEditForm/index.tsx
@@ -1,3 +1,4 @@
+import type { DateFormat } from 'types/date';
 import type { EditPetPlantRequest, PetPlantDetails } from 'types/petPlant';
 import { useId } from 'react';
 import DateInput from 'components/@common/DateInput';
@@ -29,7 +30,12 @@ import {
 } from './PetPlantEditForm.style';
 import useEditPetPlant from 'hooks/queries/pet/useEditPetPlant';
 import { PetPlantForm, usePetPlantForm } from 'hooks/usePetPlantForm';
-import { convertDateKorYear, getParticularDateFromSpecificDay, getDateToString } from 'utils/date';
+import {
+  convertDateKorYear,
+  getParticularDateFromSpecificDay,
+  getDateToString,
+  isDateFormat,
+} from 'utils/date';
 import { NUMBER, OPTIONS } from 'constants/index';
 import theme from 'style/theme.style';
 
@@ -75,8 +81,16 @@ const PetPlantEditForm = (props: PetPlantDetails) => {
       return;
     }
 
-    const requestForm: EditPetPlantRequest = {
+    const { birthDate: formBirthDate, lastWaterDate: formLastWaterDate } = form;
+
+    if (!(isDateFormat(formBirthDate) && isDateFormat(formLastWaterDate))) {
+      return;
+    }
+
+    const requestForm = {
       ...form,
+      birthDate: formBirthDate,
+      lastWaterDate: formLastWaterDate,
       waterCycle: Number(form.waterCycle),
     };
 

--- a/frontend/src/components/petPlant/PetPlantEditForm/index.tsx
+++ b/frontend/src/components/petPlant/PetPlantEditForm/index.tsx
@@ -1,5 +1,4 @@
-import type { DateFormat } from 'types/date';
-import type { EditPetPlantRequest, PetPlantDetails } from 'types/petPlant';
+import type { PetPlantDetails } from 'types/petPlant';
 import { useId } from 'react';
 import DateInput from 'components/@common/DateInput';
 import Flowerpot from 'components/@common/Icons/Flowerpot';

--- a/frontend/src/components/reminder/Card/index.tsx
+++ b/frontend/src/components/reminder/Card/index.tsx
@@ -17,7 +17,12 @@ import {
   DictionaryPlantName,
 } from './Card.style';
 import { ReminderContext } from 'contexts/reminderContext';
-import { getDateToString, getParticularDateFromSpecificDay, getStringToDate } from 'utils/date';
+import {
+  getDateToString,
+  getParticularDateFromSpecificDay,
+  getStringToDate,
+  isDateFormat,
+} from 'utils/date';
 import { dateValidate } from 'utils/validate';
 
 interface ReminderCardProps {
@@ -39,7 +44,8 @@ const ReminderCard = ({ data }: ReminderCardProps) => {
   const { isDateInRange } = dateValidate;
 
   const changeDateHandler = (changeDate: string) => {
-    //  changeDate에 대한 검증 실시. 변환하는 날이 오늘 다음날 보다 적다면 return
+    if (!isDateFormat(changeDate)) return;
+
     const variables: ChangeDateParams = {
       id: petPlantId,
       body: {
@@ -51,7 +57,7 @@ const ReminderCard = ({ data }: ReminderCardProps) => {
     return true;
   };
   const waterHandler = (waterDate: string) => {
-    // 물을 준 날이 이전에 줬던 날보다 이전이거나, 오늘 이후라면 return;
+    if (!isDateFormat(waterDate)) return;
 
     const variables: WaterPlantParams = {
       id: petPlantId,

--- a/frontend/src/components/reminder/Card/index.tsx
+++ b/frontend/src/components/reminder/Card/index.tsx
@@ -23,7 +23,7 @@ import {
   getStringToDate,
   isDateFormat,
 } from 'utils/date';
-import { dateValidate } from 'utils/validate';
+import { DateValidate } from 'utils/validate';
 
 interface ReminderCardProps {
   data: ReminderExtendType;
@@ -41,7 +41,7 @@ const ReminderCard = ({ data }: ReminderCardProps) => {
   const { petPlantId, status, image, nickName, dictionaryPlantName, dday, lastWaterDate } = data;
   const context = useContext(ReminderContext);
   const today = getDateToString();
-  const { isDateInRange } = dateValidate;
+  const { isDateInRange } = DateValidate;
 
   const changeDateHandler = (changeDate: string) => {
     if (!isDateFormat(changeDate)) return;

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -25,6 +25,8 @@ export const ERROR = {
   radioContext: '컴포넌트가 RadioProvider의 자손이 아닙니다!',
   stackContext: '컴포넌트가 StackProvider의 자손이 아닙니다!',
   toastContext: '컴포넌트가 ToastProvider의 자손이 아닙니다!',
+  dateFormat: '주어진 값은 DateFormat 타입으로 변환할 수 없습니다.',
+  yearFormat: '주어진 연도는 20세기 또는 21세기가 아닙니다.',
 } as const;
 
 export const GUIDE = {

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -27,6 +27,7 @@ export const ERROR = {
   toastContext: '컴포넌트가 ToastProvider의 자손이 아닙니다!',
   dateFormat: '주어진 값은 DateFormat 타입으로 변환할 수 없습니다.',
   yearFormat: '주어진 연도는 20세기 또는 21세기가 아닙니다.',
+  invalidDate: '올바른 날짜 형식이 아닙니다.',
 } as const;
 
 export const GUIDE = {

--- a/frontend/src/hooks/useDateInput.ts
+++ b/frontend/src/hooks/useDateInput.ts
@@ -1,11 +1,13 @@
 import { useState } from 'react';
-import { getDateToString } from 'utils/date';
+import { getDateToString, isDateFormat } from 'utils/date';
 
 const useDateInput = () => {
   const today = getDateToString();
   const [date, setDate] = useState(today);
   const changeHandler: React.ChangeEventHandler<HTMLInputElement> = (event) => {
     const { value } = event.target;
+
+    if (!isDateFormat(value)) return;
 
     setDate(value > today ? today : value);
   };

--- a/frontend/src/hooks/useModal.ts
+++ b/frontend/src/hooks/useModal.ts
@@ -22,20 +22,40 @@ const useModal = (initialState = false) => {
       off();
     }
   };
+
+  const closeOnBackdropClick = (event: MouseEvent) => {
+    if (!modalRef.current) return;
+
+    const dialog = modalRef.current.getBoundingClientRect();
+    const isClickInsideDialog =
+      dialog.top <= event.clientY &&
+      event.clientY <= dialog.top + dialog.height &&
+      dialog.left <= event.clientX &&
+      event.clientX <= dialog.left + dialog.width;
+
+    if (!isClickInsideDialog) off();
+  };
+
   const body = useRef(document.body);
 
   useEffect(() => {
     if (isOpen) {
       modalRef.current?.showModal();
+      modalRef.current?.addEventListener('click', closeOnBackdropClick);
+
       body.current.querySelector('#root')?.setAttribute('aria-hidden', 'true');
       body.current.style.overflowY = 'hidden';
+
       window.addEventListener('keydown', keyDownHandler);
     }
 
     return () => {
       modalRef.current?.close();
+      modalRef.current?.removeEventListener('click', closeOnBackdropClick);
+
       body.current.querySelector('#root')?.setAttribute('aria-hidden', 'false');
       body.current.style.overflowY = 'auto';
+
       window.removeEventListener('keydown', keyDownHandler);
     };
   }, [isOpen]);

--- a/frontend/src/hooks/useNumberInput.ts
+++ b/frontend/src/hooks/useNumberInput.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { inputValidate } from 'utils/validate';
+import { InputValidate } from 'utils/validate';
 
 interface NumberInputProps {
   maxRange?: number;
@@ -8,7 +8,7 @@ interface NumberInputProps {
 
 const useNumberInput = ({ maxRange, minRange }: NumberInputProps) => {
   const [numberValue, setNumberValue] = useState<number | ''>('');
-  const { checkNumber, checkRange, checkECode } = inputValidate;
+  const { checkNumber, checkRange, checkECode } = InputValidate;
 
   const changeCallback = (value: string) => {
     if (value === '') {

--- a/frontend/src/hooks/usePetPlantForm.ts
+++ b/frontend/src/hooks/usePetPlantForm.ts
@@ -1,6 +1,6 @@
 import type { EditPetPlantRequest } from 'types/petPlant';
 import { useReducer } from 'react';
-import { inputValidate } from 'utils/validate';
+import { InputValidate } from 'utils/validate';
 
 export type PetPlantForm = Record<keyof EditPetPlantRequest, string>;
 
@@ -46,8 +46,8 @@ const petPlantFormReducer = (petPlantForm: PetPlantForm, action: PetPlantFormAct
       }
 
       if (
-        !inputValidate.checkNumber(action.value) ||
-        !inputValidate.checkRange(Number(action.value), action.min, action.max)
+        !InputValidate.checkNumber(action.value) ||
+        !InputValidate.checkRange(Number(action.value), action.min, action.max)
       ) {
         return { ...petPlantForm };
       }

--- a/frontend/src/mocks/storage/PetPlant.ts
+++ b/frontend/src/mocks/storage/PetPlant.ts
@@ -1,4 +1,5 @@
-import { NewPetPlantRequest, PetPlantDetails } from 'types/petPlant';
+import type { NewPetPlantRequest, PetPlantDetails } from 'types/petPlant';
+import { getDateToString } from 'utils/date';
 import PET_PLANTS_DATA from '../data/petPlants';
 
 const KEY = 'MSW_PET_PLANTS';
@@ -7,7 +8,7 @@ const makeNextWaterDate = (date: string, days: number) => {
   const newDate = new Date(date);
   newDate.setDate(newDate.getDate() + days);
 
-  return `${newDate.getFullYear()}-${newDate.getMonth() + 1}-${newDate.getDay()}`;
+  return getDateToString(newDate);
 };
 
 const getAll = (): PetPlantDetails[] => {

--- a/frontend/src/pages/PetRegister/Form/index.tsx
+++ b/frontend/src/pages/PetRegister/Form/index.tsx
@@ -19,7 +19,7 @@ import {
 import useDictDetail from 'hooks/queries/dictionary/useDictDetail';
 import useRegisterPetPlant from 'hooks/queries/pet/useRegisterPetPlant';
 import { usePetPlantForm } from 'hooks/usePetPlantForm';
-import { getDateToString } from 'utils/date';
+import { getDateToString, isDateFormat } from 'utils/date';
 import { NUMBER, OPTIONS } from 'constants/index';
 
 const STACK_SIZE = 9;
@@ -98,11 +98,21 @@ const PetRegisterForm = () => {
   };
 
   const submit = () => {
-    mutate({
+    const { birthDate: formBirthDate, lastWaterDate: formLastWaterDate } = form;
+
+    if (!(isDateFormat(formBirthDate) && isDateFormat(formLastWaterDate))) {
+      return;
+    }
+
+    const requestForm = {
       ...form,
       dictionaryPlantId,
+      birthDate: formBirthDate,
+      lastWaterDate: formLastWaterDate,
       waterCycle: Number(form.waterCycle),
-    });
+    };
+
+    mutate(requestForm);
   };
 
   useEffect(() => {

--- a/frontend/src/types/date.ts
+++ b/frontend/src/types/date.ts
@@ -1,6 +1,16 @@
+type DecimalDigit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9';
+
+export type Year = `${'19' | '20'}${DecimalDigit}${DecimalDigit}`;
+
+export type Month = `0${Exclude<DecimalDigit, '0'>}` | '10' | '11' | '12';
+
+export type Day = `${'0' | '1' | '2'}${DecimalDigit}` | '30' | '31';
+
+export type DateFormat = `${Year}-${Month}-${Day}`;
+
 export interface MonthInfo {
-  year: string;
-  month: string;
+  year: Year;
+  month: Month;
   monthFirstDay: number;
   monthLastDate: number;
 }
@@ -11,19 +21,3 @@ export interface DayInfo {
   min: React.InputHTMLAttributes<HTMLInputElement>['max'];
   max: React.InputHTMLAttributes<HTMLInputElement>['min'];
 }
-
-export type Month =
-  | '01'
-  | '02'
-  | '03'
-  | '04'
-  | '05'
-  | '06'
-  | '07'
-  | '08'
-  | '09'
-  | '10'
-  | '11'
-  | '12';
-
-export type DateFormat = `${number}-${Month}-${string}`; // YYYY-MM-DD

--- a/frontend/src/types/date.ts
+++ b/frontend/src/types/date.ts
@@ -8,6 +8,8 @@ export type Day = `${'0' | '1' | '2'}${DecimalDigit}` | '30' | '31';
 
 export type DateFormat = `${Year}-${Month}-${Day}`;
 
+export type KoreanDateFormat = `${Year}년 ${Month}월 ${Day}일`;
+
 export interface MonthInfo {
   year: Year;
   month: Month;

--- a/frontend/src/types/date.ts
+++ b/frontend/src/types/date.ts
@@ -4,7 +4,7 @@ export type Year = `${'19' | '20'}${DecimalDigit}${DecimalDigit}`;
 
 export type Month = `0${Exclude<DecimalDigit, '0'>}` | '10' | '11' | '12';
 
-export type Day = `${'0' | '1' | '2'}${DecimalDigit}` | '30' | '31';
+export type Day = `0${Exclude<DecimalDigit, '0'>}` | `${'1' | '2'}${DecimalDigit}` | '30' | '31';
 
 export type DateFormat = `${Year}-${Month}-${Day}`;
 

--- a/frontend/src/types/date.ts
+++ b/frontend/src/types/date.ts
@@ -20,6 +20,6 @@ export interface MonthInfo {
 export interface DayInfo {
   idx: number;
   monthInfo: MonthInfo;
-  min: React.InputHTMLAttributes<HTMLInputElement>['max'];
-  max: React.InputHTMLAttributes<HTMLInputElement>['min'];
+  min: React.InputHTMLAttributes<HTMLInputElement>['min'];
+  max: React.InputHTMLAttributes<HTMLInputElement>['max'];
 }

--- a/frontend/src/types/history.ts
+++ b/frontend/src/types/history.ts
@@ -1,7 +1,9 @@
+import type { DateFormat } from './date';
+
 export interface HistoryResponse {
   page: number;
   size: number;
   elementSize: number;
   hasNext: boolean;
-  waterDateList: string[];
+  waterDateList: DateFormat[];
 }

--- a/frontend/src/types/petPlant.ts
+++ b/frontend/src/types/petPlant.ts
@@ -1,3 +1,4 @@
+import type { DateFormat } from './date';
 import type { DictionaryPlant } from './dictionaryPlant';
 
 export interface PetPlantDetails {
@@ -9,12 +10,12 @@ export interface PetPlantDetails {
   flowerpot: string;
   light: string;
   wind: string;
-  birthDate: string;
-  lastWaterDate: string;
+  birthDate: DateFormat;
+  lastWaterDate: DateFormat;
   waterCycle: number;
   dday: number;
   daySince: number;
-  nextWaterDate: string;
+  nextWaterDate: DateFormat;
 }
 
 export interface NewPetPlantRequest

--- a/frontend/src/types/reminder.ts
+++ b/frontend/src/types/reminder.ts
@@ -1,4 +1,5 @@
-import { PetPlantDetails } from './petPlant';
+import type { DateFormat } from './date';
+import type { PetPlantDetails } from './petPlant';
 
 export type TodayStatus = 'late' | 'today' | 'future'; // 오늘 할 일에 대한 상태
 
@@ -20,13 +21,13 @@ export interface ReminderExtendType extends Reminder {
 export interface WaterPlantParams {
   id: number;
   body: {
-    waterDate: string;
+    waterDate: DateFormat;
   };
 }
 
 export interface ChangeDateParams {
   id: number;
   body: {
-    nextWaterDate: string;
+    nextWaterDate: DateFormat;
   };
 }

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -51,8 +51,8 @@ export const isYear = (target: string): target is Year => {
 export const isKoreanDateFormat = (target: string): target is KoreanDateFormat => {
   if (target.trim().length !== 13) return false;
 
-  const [yearString, monthDateString] = target.trim().split('년');
-  const [monthString, dateFormatString] = monthDateString.split('월');
+  const [yearString, monthDateString] = target.trim().split('년 ');
+  const [monthString, dateFormatString] = monthDateString.split('월 ');
   const [dateString] = dateFormatString.split('일');
 
   return isDateFormat(`${yearString}-${monthString}-${dateString}`);
@@ -64,11 +64,8 @@ export const isKoreanDateFormat = (target: string): target is KoreanDateFormat =
  * @returns 'YYYY년 MM월 DD일'
  */
 export const convertDateKorYear = (date: string | number | Date): KoreanDateFormat => {
-  const result = new Date(date).toLocaleDateString('ko-KR', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
+  const [year, month, dateValue] = getDateToString(new Date(date)).split('-');
+  const result = `${year}년 ${month}월 ${dateValue}일`;
 
   if (!isKoreanDateFormat(result)) throw new Error(ERROR.dateFormat);
 

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -1,9 +1,9 @@
-import type { DateFormat, DayInfo, Month, MonthInfo, Year } from 'types/date';
+import type { DateFormat, DayInfo, KoreanDateFormat, Month, MonthInfo, Year } from 'types/date';
 import { ERROR } from 'constants/index';
 import { dateValidate } from './validate';
 
 /**
- * 주어진 문자열이 20, 21세기의 YYYY-MM-DD 형식을 만족하는 `DateFormat` 타입인지 반환
+ * 주어진 문자열이 20, 21세기의 'YYYY-MM-DD' 형태인지 판별합니다.
  * @param target 임의의 문자열
  * @returns `DateFormat` 형식이면 true, 아니면 false
  */
@@ -44,16 +44,36 @@ export const isYear = (target: string): target is Year => {
 };
 
 /**
+ * 주어진 문자열이 20, 21세기의 'YYYY년 MM월 DD일' 형태인지 판별합니다.
+ * @param target 임의의 문자열
+ * @returns `KoreanDateFormat` 형식이면 true, 아니면 false
+ */
+export const isKoreanDateFormat = (target: string): target is KoreanDateFormat => {
+  if (target.trim().length !== 13) return false;
+
+  const [yearString, monthDateString] = target.trim().split('년');
+  const [monthString, dateFormatString] = monthDateString.split('월');
+  const [dateString] = dateFormatString.split('일');
+
+  return isDateFormat(`${yearString}-${monthString}-${dateString}`);
+};
+
+/**
  * 받은 날짜를 한국식으로 표현합니다.
  * @param date `new Date()`를 이용해 날짜 형태로 변경할 수 있는 값
  * @returns 'YYYY년 MM월 DD일'
  */
-export const convertDateKorYear = (date: string | number | Date) =>
-  new Date(date).toLocaleDateString('ko-KR', {
+export const convertDateKorYear = (date: string | number | Date): KoreanDateFormat => {
+  const result = new Date(date).toLocaleDateString('ko-KR', {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
   });
+
+  if (!isKoreanDateFormat(result)) throw new Error(ERROR.dateFormat);
+
+  return result;
+};
 
 /**
  * 특정 날짜를 YYYY-MM-DD 형태의 string으로 반환합니다.

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -1,6 +1,6 @@
 import type { DateFormat, DayInfo, KoreanDateFormat, Month, MonthInfo, Year } from 'types/date';
 import { ERROR } from 'constants/index';
-import { dateValidate } from './validate';
+import { DateValidate } from './validate';
 
 /**
  * 주어진 문자열이 20, 21세기의 'YYYY-MM-DD' 형태인지 판별합니다.
@@ -183,7 +183,7 @@ export const getDayInfo = ({ idx, monthInfo, min, max }: DayInfo) => {
   const startDate = min ? new Date(min) : null;
   const endDate = max ? new Date(max) : null;
 
-  const isInRange = dateValidate.isDateInRange({ dateToCheck: currentDate, startDate, endDate });
+  const isInRange = DateValidate.isDateInRange({ dateToCheck: currentDate, startDate, endDate });
 
   return { date, isShow, isToday, currentDate, isInRange };
 };

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -78,6 +78,8 @@ export const convertDateKorYear = (date: string | number | Date): KoreanDateForm
  * @returns 'YYYY-MM-DD'
  */
 export const getDateToString = (date = new Date()): DateFormat => {
+  if (date.toString() === 'Invalid Date') throw new RangeError(ERROR.invalidDate);
+
   const year = date.getFullYear();
   const month = (date.getMonth() + 1).toString().padStart(2, '0') as Month;
   const day = date.getDate().toString().padStart(2, '0');
@@ -97,9 +99,18 @@ export const getDateToString = (date = new Date()): DateFormat => {
  * @return new Date(YYYY, MM, DD);
  */
 export const getStringToDate = (date: string) => {
-  if (!date.includes('-')) return new Date(date);
+  if (!date.includes('-')) {
+    const target = new Date(date);
+    if (target.toString() === 'Invalid Date') throw new RangeError(ERROR.invalidDate);
+    return target;
+  }
+
   const [year, month, day] = date.split('-').map(Number);
-  return new Date(year, month - 1, day);
+  const target = new Date(year, month - 1, day);
+
+  if (target.toString() === 'Invalid Date') throw new RangeError(ERROR.invalidDate);
+
+  return target;
 };
 
 /**
@@ -114,6 +125,10 @@ export const getDaysBetween = (one: string | number | Date, another: string | nu
     typeof another === 'string' && isDateFormat(another)
       ? getStringToDate(another)
       : new Date(another);
+
+  if (first.toString() === 'Invalid Date' || second.toString() === 'Invalid Date') {
+    throw new RangeError(ERROR.invalidDate);
+  }
 
   const diff = Math.abs(first.getTime() - second.getTime());
   const days = Math.ceil(diff / (1000 * 60 * 60 * 24));

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -60,22 +60,27 @@ export const convertDateKorYear = (date: string | number | Date) =>
  * @param date 입력 받은 특정 날짜
  * @returns 'YYYY-MM-DD'
  */
-export const getDateToString = (date = new Date()) => {
+export const getDateToString = (date = new Date()): DateFormat => {
   const year = date.getFullYear();
   const month = (date.getMonth() + 1).toString().padStart(2, '0') as Month;
   const day = date.getDate().toString().padStart(2, '0');
 
-  return `${year}-${month}-${day}`;
+  const dateString = `${year}-${month}-${day}`;
+
+  if (!isDateFormat(dateString)) throw new Error(ERROR.dateFormat);
+
+  return dateString;
 };
 
 /**
- * YYYY-MM-DD 형태의 값을 Date 형태로 반환합니다.
- * @param date YYYY-MM-DD 형태의 날짜
- * @return new Date();
+ * 문자열 형태의 날짜 값을 Date 형태로 반환합니다.
+ *
+ * IOS Safari에서 YYYY-MM-DD 형태의 문자열을 new Date()의 인자로 줄 수 없는 문제 해결을 위한 함수.
+ * @param date 문자열
+ * @return new Date(YYYY, MM, DD);
  */
-
-export const getStringToDate = (date: string | number | Date | null) => {
-  if (typeof date !== 'string') return new Date();
+export const getStringToDate = (date: string) => {
+  if (!date.includes('-')) return new Date(date);
   const [year, month, day] = date.split('-').map(Number);
   return new Date(year, month - 1, day);
 };
@@ -87,8 +92,11 @@ export const getStringToDate = (date: string | number | Date | null) => {
  * @returns 음이 아닌 정수
  */
 export const getDaysBetween = (one: string | number | Date, another: string | number | Date) => {
-  const first = getStringToDate(one);
-  const second = getStringToDate(another);
+  const first = typeof one === 'string' && isDateFormat(one) ? getStringToDate(one) : new Date(one);
+  const second =
+    typeof another === 'string' && isDateFormat(another)
+      ? getStringToDate(another)
+      : new Date(another);
 
   const diff = Math.abs(first.getTime() - second.getTime());
   const days = Math.ceil(diff / (1000 * 60 * 60 * 24));
@@ -102,7 +110,6 @@ export const getDaysBetween = (one: string | number | Date, another: string | nu
  * @param specificDay 기준이 되는 날짜 (기본값은 오늘)
  * @returns DateFormat
  */
-
 export const getParticularDateFromSpecificDay = (
   particularNumber: number,
   specificDay = new Date()
@@ -113,20 +120,22 @@ export const getParticularDateFromSpecificDay = (
 };
 
 /**
- * 날짜를 입력 받고, 해당 연,월과 첫 번째 요일 그리고 마지막 날짜를 반환하는 메서드
+ * 날짜를 입력 받아 해당 연, 월과 첫 번째 요일 그리고 마지막 날짜를 반환하는 메서드
  * @param date 현재 날짜
  * @returns MonthInfo
  */
-
 export const getMonthInfo = (date = new Date()): MonthInfo => {
-  const year = date.getFullYear(); // 연
-  const month = date.getMonth() + 1; // 월
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
   const monthFirstDay = new Date(year, month - 1).getDay(); // 첫 번째 요일
   const monthLastDate = new Date(year, month, 0).getDate(); // 마지막 날짜
 
+  const validatedYear = year.toString();
+  if (!isYear(validatedYear)) throw new Error(ERROR.yearFormat);
+
   return {
-    year: year.toString(),
-    month: month.toString().padStart(2, '0'),
+    year: validatedYear,
+    month: month.toString().padStart(2, '0') as Month,
     monthFirstDay,
     monthLastDate,
   };

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -1,5 +1,47 @@
-import { DayInfo, Month, MonthInfo } from 'types/date';
+import type { DateFormat, DayInfo, Month, MonthInfo, Year } from 'types/date';
+import { ERROR } from 'constants/index';
 import { dateValidate } from './validate';
+
+/**
+ * 주어진 문자열이 20, 21세기의 YYYY-MM-DD 형식을 만족하는 `DateFormat` 타입인지 반환
+ * @param target 임의의 문자열
+ * @returns `DateFormat` 형식이면 true, 아니면 false
+ */
+export const isDateFormat = (target: string): target is DateFormat => {
+  if (target.trim().length !== 10) return false;
+
+  const [yearString, monthString, dateString] = target.trim().split('-');
+
+  if (!yearString || !monthString || !dateString) return false;
+  if (yearString.length !== 4 || monthString.length !== 2 || dateString.length !== 2) {
+    return false;
+  }
+
+  const [year, month, dateValue] = target.trim().split('-').map(Number);
+  const date = new Date(year, month - 1, dateValue);
+
+  if (
+    year !== date.getFullYear() ||
+    month !== date.getMonth() + 1 ||
+    dateValue !== date.getDate()
+  ) {
+    return false;
+  }
+
+  if (date < new Date(1900, 1, 1) || date > new Date(2099, 12, 31)) return false;
+
+  return true;
+};
+
+/**
+ * 주어진 연도가 20세기 또는 21세기인지 판별합니다.
+ * @param target 연도를 표현하는 문자열
+ * @returns 20세기 또는 21세기면 true, 아니면 false
+ */
+export const isYear = (target: string): target is Year => {
+  const value = Number(target);
+  return value >= 1900 && value < 2100;
+};
 
 /**
  * 받은 날짜를 한국식으로 표현합니다.

--- a/frontend/src/utils/validate.ts
+++ b/frontend/src/utils/validate.ts
@@ -1,4 +1,4 @@
-export const inputValidate = {
+export const InputValidate = {
   /**
    * 값이 0~9로만 이루어진 숫자인지 확인합니다.
    * @param value 문자열 형태로 된 숫자
@@ -50,7 +50,7 @@ interface DateInRange {
   endDate?: Date | null;
 }
 
-export const dateValidate = {
+export const DateValidate = {
   isDateInRange: ({ dateToCheck, startDate, endDate }: DateInRange) => {
     const dateToCheckTime = dateToCheck.getTime();
     if (startDate && endDate) {


### PR DESCRIPTION
# 🔥 연관 이슈

- close #230 

# 🚀 작업 내용

### 1. 달력, 모달

- 오늘이 선택 불가능한 날일 경우 흐리게 표시
- 달력 월 이동을 날짜 제한 밖으로 벗어날 수 없게 설정
- 선택 가능한 날에 마우스 hover 시 표시
- 선택 불가능한 날 cursor default
- 최대/최소 날짜 제한 기본값 추가 (1945년 ~ 2099년)
- 모달 배경 클릭 시 닫기
![달력 리팩터링](https://github.com/woowacourse-teams/2023-pium/assets/77872742/87af5305-aa29-4d33-8fb2-a7950fafd095)


### 2. DateFormat 타입

- 1900년 1월 1일부터 2099년 12월 31일까지 가능
- 범위를 이렇게 설정한 이유는 2100년대도 추가하면 타입이 너무 복잡하다고 빨간줄을 띄우더라구요
- 연월일을 `-`로 표현하는 타입과 `년 월 일` 한글로 표현하는 타입 두 가지를 만들었습니다
- 해당 타입에 대해 타입 가드도 만들어서 적용했어요

# 💬 리뷰 중점사항
