### PR TITLE
feat: 반려식물 등록 시 히스토리 추가

### DIFF
--- a/backend/pium/src/main/java/com/official/pium/event/history/PetPlantHistory.java
+++ b/backend/pium/src/main/java/com/official/pium/event/history/PetPlantHistory.java
@@ -1,15 +1,17 @@
 package com.official.pium.event.history;
 
 import com.official.pium.domain.HistoryType;
-import com.official.pium.domain.PetPlant;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
 @Getter
 public class PetPlantHistory {
+
+    private static final String EMPTY = "EMPTY";
 
     private final String location;
     private final String flowerpot;
@@ -28,42 +30,14 @@ public class PetPlantHistory {
         this.lastWaterDate = lastWaterDate;
     }
 
-    public PetPlantHistory(PetPlant petPlant) {
-        this.location = petPlant.getLocation();
-        this.flowerpot = petPlant.getFlowerpot();
-        this.light = petPlant.getLight();
-        this.wind = petPlant.getWind();
-        this.waterCycle = petPlant.getWaterCycle().toString();
-        this.lastWaterDate = petPlant.getLastWaterDate().toString();
-    }
-
-    public List<HistoryEvent> generateCreateHistoryEvents(Long petPlantId, PetPlantHistory other, LocalDate date) {
+    public List<HistoryEvent> generateCreateHistoryEvents(Long petPlantId, LocalDate date) {
         List<HistoryEvent> events = new ArrayList<>();
-
-        if (!location.equals(other.location)) {
-            events.add(new HistoryEvent(petPlantId, location, other.location, HistoryType.LOCATION, date));
-        }
-
-        if (!flowerpot.equals(other.flowerpot)) {
-            events.add(new HistoryEvent(petPlantId, flowerpot, other.flowerpot, HistoryType.FLOWERPOT, date));
-        }
-
-        if (!light.equals(other.light)) {
-            events.add(new HistoryEvent(petPlantId, light, other.light, HistoryType.LIGHT, date));
-        }
-
-        if (!wind.equals(other.wind)) {
-            events.add(new HistoryEvent(petPlantId, wind, other.wind, HistoryType.WIND, date));
-        }
-
-        if (!waterCycle.equals(other.waterCycle)) {
-            events.add(new HistoryEvent(petPlantId, waterCycle, other.waterCycle, HistoryType.WATER_CYCLE, date));
-        }
-
-        if (!lastWaterDate.equals(other.lastWaterDate)) {
-            events.add(new HistoryEvent(petPlantId, lastWaterDate, other.lastWaterDate, HistoryType.LAST_WATER_DATE, date));
-        }
-
+        events.add(new HistoryEvent(petPlantId, EMPTY, location, HistoryType.LOCATION, date));
+        events.add(new HistoryEvent(petPlantId, EMPTY, flowerpot, HistoryType.FLOWERPOT, date));
+        events.add(new HistoryEvent(petPlantId, EMPTY, light, HistoryType.LIGHT, date));
+        events.add(new HistoryEvent(petPlantId, EMPTY, wind, HistoryType.WIND, date));
+        events.add(new HistoryEvent(petPlantId, EMPTY, waterCycle, HistoryType.WATER_CYCLE, date));
+        events.add(new HistoryEvent(petPlantId, EMPTY, lastWaterDate, HistoryType.LAST_WATER_DATE, date));
         return events;
     }
 }

--- a/backend/pium/src/test/java/com/official/pium/acceptance/HistoryApiTest.java
+++ b/backend/pium/src/test/java/com/official/pium/acceptance/HistoryApiTest.java
@@ -21,6 +21,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 import static com.official.pium.fixture.PetPlantFixture.REQUEST.generatePetPlantCreateRequest;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -273,14 +274,14 @@ public class HistoryApiTest extends AcceptanceTest {
 
             ExtractableResponse<Response> petPlantResponse = 반려_식물_단건_조회(반려_식물_ID);
             List<String> currentResponses = response.jsonPath().getList("data.content.current");
-            assertSoftly(softly -> softly.assertThat(currentResponses).containsExactlyInAnyOrder(
+            assertThat(currentResponses).containsExactlyInAnyOrder(
                     petPlantResponse.jsonPath().getString("location"),
                     petPlantResponse.jsonPath().getString("flowerpot"),
                     petPlantResponse.jsonPath().getString("light"),
                     petPlantResponse.jsonPath().getString("wind"),
                     petPlantResponse.jsonPath().getString("waterCycle"),
                     petPlantResponse.jsonPath().getString("lastWaterDate")
-            ));
+            );
         }
     }
 

--- a/backend/pium/src/test/java/com/official/pium/acceptance/HistoryApiTest.java
+++ b/backend/pium/src/test/java/com/official/pium/acceptance/HistoryApiTest.java
@@ -1,9 +1,5 @@
 package com.official.pium.acceptance;
 
-import static com.official.pium.fixture.PetPlantFixture.REQUEST.generatePetPlantCreateRequest;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-
 import com.official.pium.AcceptanceTest;
 import com.official.pium.domain.DictionaryPlant;
 import com.official.pium.domain.Member;
@@ -14,15 +10,20 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.time.LocalDate;
-import java.util.List;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.official.pium.fixture.PetPlantFixture.REQUEST.generatePetPlantCreateRequest;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
@@ -153,10 +154,10 @@ public class HistoryApiTest extends AcceptanceTest {
                     .statusCode(HttpStatus.OK.value())
                     .extract();
 
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.jsonPath().getInt("page")).isEqualTo(1000);
                 softly.assertThat(response.jsonPath().getInt("size")).isEqualTo(1);
-                softly.assertThat(response.jsonPath().getInt("elementSize")).isEqualTo(4);
+                softly.assertThat(response.jsonPath().getInt("elementSize")).isEqualTo(10);
                 softly.assertThat(response.jsonPath().getBoolean("hasNext")).isFalse();
                 softly.assertThat(response.jsonPath().getList("data")).isEmpty();
             });
@@ -185,8 +186,8 @@ public class HistoryApiTest extends AcceptanceTest {
                     .statusCode(HttpStatus.OK.value())
                     .extract();
 
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(response.jsonPath().getInt("elementSize")).isEqualTo(1);
+            assertSoftly(softly -> {
+                softly.assertThat(response.jsonPath().getInt("elementSize")).isEqualTo(7);
                 softly.assertThat(response.jsonPath().getList("data"))
                         .usingRecursiveComparison()
                         .comparingOnlyFields("date")
@@ -221,15 +222,65 @@ public class HistoryApiTest extends AcceptanceTest {
                     .statusCode(HttpStatus.OK.value())
                     .extract();
 
-            SoftAssertions.assertSoftly(softly -> {
+            assertSoftly(softly -> {
                 softly.assertThat(response.jsonPath().getInt("page")).isEqualTo(pageRequestParam);
                 softly.assertThat(response.jsonPath().getInt("size")).isEqualTo(sizeRequestParam);
-                softly.assertThat(response.jsonPath().getInt("elementSize")).isEqualTo(1);
+                softly.assertThat(response.jsonPath().getInt("elementSize")).isEqualTo(7);
                 softly.assertThat(response.jsonPath().getList("data"))
                         .usingRecursiveComparison()
                         .comparingOnlyFields("date")
                         .isEqualTo(List.of(waterDate.toString()));
             });
+        }
+
+        @Test
+        void 반려_식물_최초_등록_시_히스토리_생성() {
+            DictionaryPlant dictionaryPlant = dictionaryPlantSupport.builder().build();
+            LocalDate registeredDate = LocalDate.of(2020, 4, 5);
+            PetPlantCreateRequest petPlantCreateRequest = generatePetPlantRequestByLastWaterDate(
+                    dictionaryPlant.getId(), registeredDate);
+
+            Long 반려_식물_ID = 반려_식물_등록_요청(petPlantCreateRequest);
+            int pageRequestParam = 0;
+            int sizeRequestParam = 10;
+            ExtractableResponse<Response> response = RestAssured
+                    .given()
+                    .queryParam("petPlantId", 반려_식물_ID)
+                    .queryParam("page", pageRequestParam)
+                    .queryParam("size", sizeRequestParam)
+                    .log().all()
+                    .header("Authorization", member.getEmail())
+                    .when()
+                    .get("/history")
+                    .then()
+                    .log().all()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract();
+
+            assertSoftly(softly -> {
+                softly.assertThat(response.jsonPath().getInt("page")).isEqualTo(pageRequestParam);
+                softly.assertThat(response.jsonPath().getInt("size")).isEqualTo(sizeRequestParam);
+                softly.assertThat(response.jsonPath().getInt("elementSize")).isEqualTo(6);
+                softly.assertThat(response.jsonPath().getList("data"))
+                        .usingRecursiveComparison()
+                        .comparingOnlyFields("date")
+                        .isEqualTo(List.of(registeredDate.toString()));
+                softly.assertThat(response.jsonPath().getList("data.content"))
+                        .usingRecursiveComparison()
+                        .comparingOnlyFields("previous")
+                        .isEqualTo(List.of("EMPTY"));
+            });
+
+            ExtractableResponse<Response> petPlantResponse = 반려_식물_단건_조회(반려_식물_ID);
+            List<String> currentResponses = response.jsonPath().getList("data.content.current");
+            assertSoftly(softly -> softly.assertThat(currentResponses).containsExactlyInAnyOrder(
+                    petPlantResponse.jsonPath().getString("location"),
+                    petPlantResponse.jsonPath().getString("flowerpot"),
+                    petPlantResponse.jsonPath().getString("light"),
+                    petPlantResponse.jsonPath().getString("wind"),
+                    petPlantResponse.jsonPath().getString("waterCycle"),
+                    petPlantResponse.jsonPath().getString("lastWaterDate")
+            ));
         }
     }
 
@@ -282,5 +333,18 @@ public class HistoryApiTest extends AcceptanceTest {
                 .birthDate(LocalDate.of(2000, 7, 2))
                 .lastWaterDate(lastWaterDate)
                 .build();
+    }
+
+    private ExtractableResponse<Response> 반려_식물_단건_조회(Long petPlantId) {
+        return RestAssured
+                .given()
+                .log().all()
+                .header("Authorization", member.getEmail())
+                .when()
+                .get("/pet-plants/{id}", petPlantId)
+                .then()
+                .log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract();
     }
 }

--- a/backend/pium/src/test/java/com/official/pium/service/HistoryServiceTest.java
+++ b/backend/pium/src/test/java/com/official/pium/service/HistoryServiceTest.java
@@ -1,16 +1,11 @@
 package com.official.pium.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import com.official.pium.IntegrationTest;
 import com.official.pium.domain.History;
 import com.official.pium.domain.HistoryType;
 import com.official.pium.domain.Member;
 import com.official.pium.domain.PetPlant;
 import com.official.pium.service.dto.HistoryResponse;
-import java.time.LocalDate;
-import java.util.NoSuchElementException;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -19,6 +14,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+
+import java.time.LocalDate;
+import java.util.NoSuchElementException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
@@ -101,6 +102,7 @@ class HistoryServiceTest extends IntegrationTest {
 
         assertThat(historyResponse.isHasNext()).isFalse();
     }
+
 
     private History createHistory(PetPlant petPlant, LocalDate date) {
         return historySupport.builder()

--- a/backend/pium/src/test/java/com/official/pium/service/HistoryServiceTest.java
+++ b/backend/pium/src/test/java/com/official/pium/service/HistoryServiceTest.java
@@ -103,7 +103,6 @@ class HistoryServiceTest extends IntegrationTest {
         assertThat(historyResponse.isHasNext()).isFalse();
     }
 
-
     private History createHistory(PetPlant petPlant, LocalDate date) {
         return historySupport.builder()
                 .petPlant(petPlant)


### PR DESCRIPTION
# 🔥 연관 이슈

- close #218 

# 🚀 작업 내용

반려 식물을 등록할 때 최초 히스토리 로그가 총 여섯 개 추가됩니다.

# 💬 리뷰 중점사항
`PetPlantService`의 create 메소드 봐주시면 되겠습니다.