### PR TITLE
feat: secondLastWaterDate 추가

### DIFF
--- a/backend/pium/src/main/java/com/official/pium/event/history/PetPlantHistory.java
+++ b/backend/pium/src/main/java/com/official/pium/event/history/PetPlantHistory.java
@@ -1,12 +1,11 @@
 package com.official.pium.event.history;
 
 import com.official.pium.domain.HistoryType;
-import lombok.Builder;
-import lombok.Getter;
-
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
 
 @Getter
 public class PetPlantHistory {
@@ -37,7 +36,7 @@ public class PetPlantHistory {
         events.add(new HistoryEvent(petPlantId, EMPTY, light, HistoryType.LIGHT, date));
         events.add(new HistoryEvent(petPlantId, EMPTY, wind, HistoryType.WIND, date));
         events.add(new HistoryEvent(petPlantId, EMPTY, waterCycle, HistoryType.WATER_CYCLE, date));
-        events.add(new HistoryEvent(petPlantId, EMPTY, lastWaterDate, HistoryType.LAST_WATER_DATE, date));
+        events.add(new HistoryEvent(petPlantId, EMPTY, lastWaterDate, HistoryType.LAST_WATER_DATE, LocalDate.parse(lastWaterDate)));
         return events;
     }
 }

--- a/backend/pium/src/main/java/com/official/pium/mapper/PetPlantMapper.java
+++ b/backend/pium/src/main/java/com/official/pium/mapper/PetPlantMapper.java
@@ -57,6 +57,31 @@ public class PetPlantMapper {
                 .build();
     }
 
+    public static PetPlantResponse toPetPlantResponse(PetPlant petPlant, Long dday, Long daySince, LocalDate secondLastWaterDate) {
+        DictionaryPlant dictionaryPlant = petPlant.getDictionaryPlant();
+        return PetPlantResponse.builder()
+                .id(petPlant.getId())
+                .nickname(petPlant.getNickname())
+                .imageUrl(petPlant.getImageUrl())
+                .location(petPlant.getLocation())
+                .flowerpot(petPlant.getFlowerpot())
+                .light(petPlant.getLight())
+                .wind(petPlant.getWind())
+                .birthDate(petPlant.getBirthDate())
+                .lastWaterDate(petPlant.getLastWaterDate())
+                .waterCycle(petPlant.getWaterCycle())
+                .dday(dday)
+                .nextWaterDate(petPlant.getNextWaterDate())
+                .daySince(daySince)
+                .dictionaryPlant(PetPlantResponse.DictionaryPlantResponse.builder()
+                        .id(dictionaryPlant.getId())
+                        .name(dictionaryPlant.getName())
+                        .build()
+                )
+                .secondLastWaterDate(secondLastWaterDate)
+                .build();
+    }
+
     public static SinglePetPlantResponse toSinglePetPlantResponse(PetPlant petPlant, Long daySince) {
         return SinglePetPlantResponse.builder()
                 .id(petPlant.getId())

--- a/backend/pium/src/main/java/com/official/pium/service/PetPlantService.java
+++ b/backend/pium/src/main/java/com/official/pium/service/PetPlantService.java
@@ -16,6 +16,9 @@ import com.official.pium.service.dto.PetPlantCreateRequest;
 import com.official.pium.service.dto.PetPlantResponse;
 import com.official.pium.service.dto.PetPlantUpdateRequest;
 import com.official.pium.service.dto.SinglePetPlantResponse;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
@@ -23,10 +26,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
-import java.util.List;
-import java.util.NoSuchElementException;
 
 @Service
 @Transactional(readOnly = true)
@@ -68,6 +67,11 @@ public class PetPlantService {
         Long dday = petPlant.calculateDday(LocalDate.now());
         Long daySince = petPlant.calculateDaySince(LocalDate.now());
 
+        Page<History> secondLastWaterDatePage = historyRepository.findAllByPetPlantIdAndHistoryCategoryHistoryType(petPlant.getId(), HistoryType.LAST_WATER_DATE, PageRequest.of(1, 1, Direction.DESC, "date"));
+        if (!secondLastWaterDatePage.isEmpty()) {
+            LocalDate secondLastWaterDate = secondLastWaterDatePage.getContent().get(0).getDate();
+            return PetPlantMapper.toPetPlantResponse(petPlant, dday, daySince, secondLastWaterDate);
+        }
         return PetPlantMapper.toPetPlantResponse(petPlant, dday, daySince);
     }
 

--- a/backend/pium/src/main/java/com/official/pium/service/ReminderService.java
+++ b/backend/pium/src/main/java/com/official/pium/service/ReminderService.java
@@ -42,9 +42,9 @@ public class ReminderService {
 
         String previousWaterDate = petPlant.getLastWaterDate().toString();
         petPlant.water(reminderCreateRequest.getWaterDate());
-        String currentWaterDate = petPlant.getLastWaterDate().toString();
+        LocalDate currentWaterDate = petPlant.getLastWaterDate();
 
-        publisher.publishEvent(new HistoryEvent(petPlantId, previousWaterDate, currentWaterDate, HistoryType.LAST_WATER_DATE, LocalDate.now()));
+        publisher.publishEvent(new HistoryEvent(petPlantId, previousWaterDate, currentWaterDate.toString(), HistoryType.LAST_WATER_DATE, currentWaterDate));
     }
 
     @Transactional

--- a/backend/pium/src/main/java/com/official/pium/service/dto/PetPlantResponse.java
+++ b/backend/pium/src/main/java/com/official/pium/service/dto/PetPlantResponse.java
@@ -30,6 +30,9 @@ public class PetPlantResponse {
 
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate lastWaterDate;
+    
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate secondLastWaterDate;
 
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate nextWaterDate;


### PR DESCRIPTION
- 반려 식물 정보 등록/수정 시 lastWaterDate에 대한 History는 date == lastWaterDate로 반영

# 🔥 연관 이슈

- close #221 

# 🚀 작업 내용

- [x] 반려 식물 단건 조회시 secondLastWaterDate 추가
- [x] 히스토리 등록, 수정 시 date를 lastWaterDate와 같게 기록

# 💬 리뷰 중점사항

히스토리 등록, 수정 시 date를 lastWaterDate와 같게 기록하도록 수정했습니다.
해당 로직과 관련하여 이해가 어려운 부분이 있으시다면 말씀 부탁드립니다~