### PR TITLE
refactor: 마이페이지 회원 탈퇴 버튼 위치를 수정한다.

### DIFF
--- a/frontend/src/components/@common/ContentHeader/ContentHeader.stories.tsx
+++ b/frontend/src/components/@common/ContentHeader/ContentHeader.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ContentHeader from '.';
+
+const meta: Meta<typeof ContentHeader> = {
+  component: ContentHeader,
+  args: {},
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ContentHeader>;
+
+export const Default: Story = {
+  args: {
+    title: '콘텐츠 헤더 입니다.',
+  },
+};

--- a/frontend/src/components/@common/ContentHeader/ContentHeader.style.ts
+++ b/frontend/src/components/@common/ContentHeader/ContentHeader.style.ts
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+
+export const HeaderBox = styled.header`
+  position: sticky;
+  z-index: ${({ theme: { zIndex } }) => zIndex.sticky};
+  top: 0;
+
+  display: flex;
+  align-items: center;
+
+  height: 68px;
+
+  background: ${(props) => props.theme.color.background};
+  border-bottom: solid 1px ${(props) => props.theme.color.gray};
+`;
+
+export const Title = styled.p`
+  width: 100%;
+  font: normal 2.4rem /3.2rem 'GmarketSans';
+  text-align: center;
+`;

--- a/frontend/src/components/@common/ContentHeader/index.tsx
+++ b/frontend/src/components/@common/ContentHeader/index.tsx
@@ -1,0 +1,15 @@
+import { HeaderBox, Title } from './ContentHeader.style';
+
+interface ContentHeaderProps {
+  title: string;
+}
+
+const ContentHeader = ({ title }: ContentHeaderProps) => {
+  return (
+    <HeaderBox>
+      <Title>{title}</Title>
+    </HeaderBox>
+  );
+};
+
+export default ContentHeader;

--- a/frontend/src/components/@common/VerticalDivider/VerticalDivider.style.ts
+++ b/frontend/src/components/@common/VerticalDivider/VerticalDivider.style.ts
@@ -2,7 +2,9 @@ import styled from 'styled-components';
 
 type Pixel = `${number}px`;
 
-const VerticalDivider = styled.div<{ height: Pixel }>`
+const VerticalDivider = styled.div.attrs({
+  'aria-hidden': true,
+})<{ height: Pixel }>`
   width: 1px; /* 세로 선의 너비를 조절할 수 있습니다. */
   height: ${({ height }) => height};
   background: ${({ theme: { color } }) => color.gray}; /* 세로 선의 색상을 지정합니다. */

--- a/frontend/src/components/@common/VerticalDivider/VerticalDivider.style.ts
+++ b/frontend/src/components/@common/VerticalDivider/VerticalDivider.style.ts
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+type Pixel = `${number}px`;
+
+const VerticalDivider = styled.div<{ height: Pixel }>`
+  width: 1px; /* 세로 선의 너비를 조절할 수 있습니다. */
+  height: ${({ height }) => height};
+  background: ${({ theme: { color } }) => color.gray}; /* 세로 선의 색상을 지정합니다. */
+`;
+
+export default VerticalDivider;

--- a/frontend/src/pages/MyPage/MyPage.style.ts
+++ b/frontend/src/pages/MyPage/MyPage.style.ts
@@ -1,45 +1,38 @@
 import styled from 'styled-components';
 
 export const Wrapper = styled.main`
+  position: relative;
   display: flex;
   flex-direction: column;
-`;
-
-export const TitleBox = styled.div`
-  width: 100%;
-  height: 68px;
-  text-align: center;
-`;
-
-export const Title = styled.p`
-  font: 900 4rem/6.8rem 'GmarketSans';
+  height: calc(100% - 68px);
 `;
 
 export const ButtonBox = styled.section`
+  position: absolute;
+  bottom: 68px;
+
   display: flex;
-  flex-direction: column;
   gap: 16px;
   align-items: center;
+  justify-content: center;
 
   width: 100%;
-  margin: 300px auto;
 
   button {
     cursor: pointer;
   }
 `;
 
-const Button = styled.button`
-  width: 270px;
+export const Button = styled.button`
   height: 45px;
-  background: #333333;
+  color: ${({ theme: { color } }) => color.gray};
   border-radius: 8px;
 `;
 
-export const Logout = styled(Button)`
-  background: ${({ theme: { color } }) => color.grayLight};
-`;
+type Pixel = `${number}px`;
 
-export const Withdraw = styled(Button)`
-  background: ${({ theme: { color } }) => color.gray};
+export const VerticalDivider = styled.div<{ height: Pixel }>`
+  width: 1px; /* 세로 선의 너비를 조절할 수 있습니다. */
+  height: ${({ height }) => height};
+  background: ${({ theme: { color } }) => color.gray}; /* 세로 선의 색상을 지정합니다. */
 `;

--- a/frontend/src/pages/MyPage/MyPage.style.ts
+++ b/frontend/src/pages/MyPage/MyPage.style.ts
@@ -28,11 +28,3 @@ export const Button = styled.button`
   color: ${({ theme: { color } }) => color.gray};
   border-radius: 8px;
 `;
-
-type Pixel = `${number}px`;
-
-export const VerticalDivider = styled.div<{ height: Pixel }>`
-  width: 1px; /* 세로 선의 너비를 조절할 수 있습니다. */
-  height: ${({ height }) => height};
-  background: ${({ theme: { color } }) => color.gray}; /* 세로 선의 색상을 지정합니다. */
-`;

--- a/frontend/src/pages/MyPage/index.tsx
+++ b/frontend/src/pages/MyPage/index.tsx
@@ -1,6 +1,7 @@
 import ContentHeader from 'components/@common/ContentHeader';
 import Navbar from 'components/@common/Navbar';
-import { Button, ButtonBox, VerticalDivider, Wrapper } from './MyPage.style';
+import VerticalDivider from 'components/@common/VerticalDivider/VerticalDivider.style';
+import { Button, ButtonBox, Wrapper } from './MyPage.style';
 import useCheckSessionId from 'hooks/queries/auth/useCheckSessionId';
 import useLogout from 'hooks/queries/auth/useLogout';
 import useWithdraw from 'hooks/queries/auth/useWithdraw';
@@ -32,7 +33,7 @@ const MyPage = () => {
           <Button type="button" onClick={handleLogout}>
             로그아웃
           </Button>
-          <VerticalDivider height={`${12}px`} />
+          <VerticalDivider height={'12px'} />
           <Button type="button" onClick={handleWithdraw}>
             회원 탈퇴
           </Button>

--- a/frontend/src/pages/MyPage/index.tsx
+++ b/frontend/src/pages/MyPage/index.tsx
@@ -1,6 +1,6 @@
-import Loading from 'pages/Loading';
+import ContentHeader from 'components/@common/ContentHeader';
 import Navbar from 'components/@common/Navbar';
-import { ButtonBox, Logout, Title, TitleBox, Withdraw, Wrapper } from './MyPage.style';
+import { Button, ButtonBox, VerticalDivider, Wrapper } from './MyPage.style';
 import useCheckSessionId from 'hooks/queries/auth/useCheckSessionId';
 import useLogout from 'hooks/queries/auth/useLogout';
 import useWithdraw from 'hooks/queries/auth/useWithdraw';
@@ -26,17 +26,16 @@ const MyPage = () => {
 
   return (
     <>
+      <ContentHeader title="마이페이지" />
       <Wrapper>
-        <TitleBox>
-          <Title>마이페이지</Title>
-        </TitleBox>
         <ButtonBox>
-          <Logout type="button" onClick={handleLogout}>
+          <Button type="button" onClick={handleLogout}>
             로그아웃
-          </Logout>
-          <Withdraw type="button" onClick={handleWithdraw}>
+          </Button>
+          <VerticalDivider height={`${12}px`} />
+          <Button type="button" onClick={handleWithdraw}>
             회원 탈퇴
-          </Withdraw>
+          </Button>
         </ButtonBox>
       </Wrapper>
       <Navbar />

--- a/frontend/src/pages/PetPlantCardList/PetPlantCardList.style.ts
+++ b/frontend/src/pages/PetPlantCardList/PetPlantCardList.style.ts
@@ -1,6 +1,6 @@
 import { styled } from 'styled-components';
 
-export const Wrapper = styled.div`
+export const Wrapper = styled.main`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -8,11 +8,6 @@ export const Wrapper = styled.div`
   width: 100%;
   height: 100%;
   padding-bottom: 68px;
-`;
-
-export const Title = styled.p`
-  margin: 32px 0;
-  font-size: 2rem;
 `;
 
 export const CardList = styled.div`

--- a/frontend/src/pages/PetPlantCardList/index.tsx
+++ b/frontend/src/pages/PetPlantCardList/index.tsx
@@ -1,7 +1,8 @@
 import { Link, generatePath } from 'react-router-dom';
+import ContentHeader from 'components/@common/ContentHeader';
 import Navbar from 'components/@common/Navbar';
 import PetCard from 'components/petPlant/PetPlantCard';
-import { CardList, RegisterButton, Title, Wrapper } from './PetPlantCardList.style';
+import { CardList, RegisterButton, Wrapper } from './PetPlantCardList.style';
 import usePetPlantCardList from 'hooks/queries/petPlant/usePetPlantCardList';
 import { URL_PATH } from 'constants/index';
 
@@ -9,8 +10,8 @@ const PetPlantCardList = () => {
   const { data: petPlantCardList } = usePetPlantCardList();
   return (
     <>
+      <ContentHeader title="나의 식물 카드" />
       <Wrapper>
-        <Title>나의 식물 카드</Title>
         <CardList>
           <Link to={URL_PATH.petRegisterSearch} aria-label="식물 추가로 이동">
             <RegisterButton type="button">+</RegisterButton>

--- a/frontend/src/pages/Reminder/Reminder.style.ts
+++ b/frontend/src/pages/Reminder/Reminder.style.ts
@@ -22,26 +22,6 @@ export const Wrapper = styled.div<BackgroundProps>`
   background: ${({ status }) => convertReminderBackground[status]};
 `;
 
-export const HeaderBox = styled.header`
-  position: sticky;
-  z-index: ${({ theme: { zIndex } }) => zIndex.sticky};
-  top: 0;
-
-  display: flex;
-  align-items: center;
-
-  height: 68px;
-
-  background: ${(props) => props.theme.color.background};
-  border-bottom: solid 1px ${(props) => props.theme.color.gray};
-`;
-
-export const Title = styled.p`
-  width: 100%;
-  font: normal 2.4rem /3.2rem 'GmarketSans';
-  text-align: center;
-`;
-
 export const ContentBox = styled.main`
   width: 100%;
   margin: 0 auto;

--- a/frontend/src/pages/Reminder/index.tsx
+++ b/frontend/src/pages/Reminder/index.tsx
@@ -1,6 +1,7 @@
+import ContentHeader from 'components/@common/ContentHeader';
 import Navbar from 'components/@common/Navbar';
 import MonthBox from 'components/reminder/MonthBox';
-import { ContentBox, HeaderBox, Title, Wrapper } from './Reminder.style';
+import { ContentBox, Wrapper } from './Reminder.style';
 import ReminderProvider from 'contexts/reminderContext';
 import useReminderHooks from 'hooks/useReminderHooks';
 
@@ -17,9 +18,7 @@ const Reminder = () => {
     <>
       <ReminderProvider waterCallback={waterMutate} changeDateCallback={changeDateMutate}>
         <Wrapper status={reminderData.status}>
-          <HeaderBox>
-            <Title>리마인더</Title>
-          </HeaderBox>
+          <ContentHeader title="리마인더" />
           <ContentBox>{reminderBox}</ContentBox>
         </Wrapper>
       </ReminderProvider>

--- a/frontend/src/style/Global.style.ts
+++ b/frontend/src/style/Global.style.ts
@@ -17,6 +17,7 @@ export const GlobalStyle = createGlobalStyle`
   body {
     scrollbar-width: none;
     font-size: 62.5%;
+
   }
 
   body::-webkit-scrollbar {


### PR DESCRIPTION
# 🔥 연관 이슈

- close #329 

# 🚀 작업 내용
![image](https://github.com/woowacourse-teams/2023-pium/assets/50974359/eff32564-499d-4714-97fa-3078c92731e4)
마이 페이지에 있는 회원 탈퇴 버튼을 아래에 삽입했습니다. 

그리고 리마인더, 마이페이지, 내 식물 보기의 콘텐츠 헤더가 모두 다른 것 같아서 하나로 통일하기 위해 `contentHeader`라는 컴포넌트를 만들었습니다. 


# 💬 리뷰 중점사항
1. 회원 탈퇴 버튼의 위치에 대한 생각
2. 공통적으로 만든 콘텐츠 헤더에 대한 생각
3. `verticalDivider`라는 컴포넌트를 살짝 만들었는데, 해당 컴포넌트에 넘기는 파라미터의 타입을 한번 봐주시면 감사하겠습니다.
