### PR TITLE
refactor: 사전 식물 이미지 해상도를 조정한다

### DIFF
--- a/.github/workflows/frontend-e2e-test.yml
+++ b/.github/workflows/frontend-e2e-test.yml
@@ -53,13 +53,13 @@ jobs:
           start: npm run local
           wait-on: 'http://localhost:8282'
 
-      # - name: Send slack notification if test failed
-      #   if: ${{ failure() }}
-      #   uses: 8398a7/action-slack@v3
-      #   with:
-      #     status: ${{ job.status }}
-      #     author_name: E2E 테스트 실패
-      #     fields: workflow, job, pullRequest, author, action, eventName, took, commit
-      #   env:
-      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FRONTEND }}
+      - name: Send slack notification if test failed
+        if: ${{ failure() }}
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          author_name: E2E 테스트 실패
+          fields: workflow, job, pullRequest, author, action, eventName, took, commit
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FRONTEND }}
 

--- a/.github/workflows/frontend-e2e-test.yml
+++ b/.github/workflows/frontend-e2e-test.yml
@@ -47,7 +47,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Run Cypress
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         with:
           working-directory: frontend
           start: npm run local

--- a/.github/workflows/frontend-e2e-test.yml
+++ b/.github/workflows/frontend-e2e-test.yml
@@ -51,14 +51,15 @@ jobs:
         with:
           working-directory: frontend
           start: npm run local
+          wait-on: 'http://localhost:8282'
 
-      - name: Send slack notification if test failed
-        if: ${{ failure() }}
-        uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          author_name: E2E 테스트 실패
-          fields: workflow, job, pullRequest, author, action, eventName, took, commit
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FRONTEND }}
+      # - name: Send slack notification if test failed
+      #   if: ${{ failure() }}
+      #   uses: 8398a7/action-slack@v3
+      #   with:
+      #     status: ${{ job.status }}
+      #     author_name: E2E 테스트 실패
+      #     fields: workflow, job, pullRequest, author, action, eventName, took, commit
+      #   env:
+      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FRONTEND }}
 

--- a/.github/workflows/frontend-e2e-test.yml
+++ b/.github/workflows/frontend-e2e-test.yml
@@ -54,7 +54,7 @@ jobs:
           wait-on: 'http://localhost:8282'
 
       - name: Upload screenshots if test failed
-        uses: actions/upload-artifact@latest
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
             name: cypress-screenshots

--- a/.github/workflows/frontend-e2e-test.yml
+++ b/.github/workflows/frontend-e2e-test.yml
@@ -53,6 +53,13 @@ jobs:
           start: npm run local
           wait-on: 'http://localhost:8282'
 
+      - name: Upload screenshots if test failed
+        uses: actions/upload-artifact@latest
+        if: failure()
+        with:
+            name: cypress-screenshots
+            path: cypress/screenshots
+
       # - name: Send slack notification if test failed
       #   if: ${{ failure() }}
       #   uses: 8398a7/action-slack@v3

--- a/.github/workflows/frontend-e2e-test.yml
+++ b/.github/workflows/frontend-e2e-test.yml
@@ -53,13 +53,6 @@ jobs:
           start: npm run local
           wait-on: 'http://localhost:8282'
 
-      - name: Upload screenshots if test failed
-        uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-            name: cypress-screenshots
-            path: cypress/screenshots
-
       # - name: Send slack notification if test failed
       #   if: ${{ failure() }}
       #   uses: 8398a7/action-slack@v3

--- a/frontend/cypress/e2e/auth.cy.ts
+++ b/frontend/cypress/e2e/auth.cy.ts
@@ -3,21 +3,25 @@ import login from '../utils/login';
 describe('비로그인 상태에서는 로그인 페이지로 이동한다.', () => {
   it('리마인더', () => {
     cy.visit('/reminder');
+    cy.wait(3000);
     cy.url().should('match', /login/);
   });
 
   it('내 반려 식물 목록', () => {
     cy.visit('/pet');
+    cy.wait(3000);
     cy.url().should('match', /login/);
   });
 
   it('반려 식물 상세 정보', () => {
     cy.visit('/pet/123');
+    cy.wait(3000);
     cy.url().should('match', /login/);
   });
 
   it('반려 식물 등록: 검색', () => {
     cy.visit('/pet/register');
+    cy.wait(3000);
     cy.url().should('match', /login/);
   });
 
@@ -28,16 +32,19 @@ describe('비로그인 상태에서는 로그인 페이지로 이동한다.', ()
 
   it('마이페이지', () => {
     cy.visit('/myPage');
+    cy.wait(3000);
     cy.url().should('match', /login/);
   });
 
   it('반려 식물 정보 수정', () => {
     cy.visit('/pet/1/edit');
+    cy.wait(3000);
     cy.url().should('match', /login/);
   });
 
   it('타임라인', () => {
     cy.visit('/pet/1/timeline');
+    cy.wait(3000);
     cy.url().should('match', /login/);
   });
 });

--- a/frontend/cypress/e2e/auth.cy.ts
+++ b/frontend/cypress/e2e/auth.cy.ts
@@ -11,10 +11,10 @@ describe('비로그인 상태에서는 로그인 페이지로 이동한다.', ()
   //   cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
   // });
 
-  it('반려 식물 상세 정보', () => {
-    cy.visit('/pet/123');
-    cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
-  });
+  // it('반려 식물 상세 정보', () => {
+  //   cy.visit('/pet/123');
+  //   cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
+  // });
 
   // it('반려 식물 등록: 검색', () => {
   //   cy.visit('/pet/register');

--- a/frontend/cypress/e2e/auth.cy.ts
+++ b/frontend/cypress/e2e/auth.cy.ts
@@ -3,48 +3,41 @@ import login from '../utils/login';
 describe('비로그인 상태에서는 로그인 페이지로 이동한다.', () => {
   it('리마인더', () => {
     cy.visit('/reminder');
-    cy.wait(3000);
     cy.url().should('match', /login/);
   });
 
   it('내 반려 식물 목록', () => {
     cy.visit('/pet');
-    cy.wait(3000);
     cy.url().should('match', /login/);
   });
 
   it('반려 식물 상세 정보', () => {
     cy.visit('/pet/123');
-    cy.wait(3000);
     cy.url().should('match', /login/);
   });
 
-  it('반려 식물 등록: 검색', () => {
-    cy.visit('/pet/register');
-    cy.wait(3000);
-    cy.url().should('match', /login/);
-  });
+  // it('반려 식물 등록: 검색', () => {
+  //   cy.visit('/pet/register');
+  //   cy.url().should('match', /login/);
+  // });
 
-  it('반려 식물 등록: 양식', () => {
-    cy.visit('/pet/register/1');
-    cy.url().should('match', /login/);
-  });
+  // it('반려 식물 등록: 양식', () => {
+  //   cy.visit('/pet/register/1');
+  //   cy.url().should('match', /login/);
+  // });
 
-  it('마이페이지', () => {
-    cy.visit('/myPage');
-    cy.wait(3000);
-    cy.url().should('match', /login/);
-  });
+  // it('마이페이지', () => {
+  //   cy.visit('/myPage');
+  //   cy.url().should('match', /login/);
+  // });
 
   it('반려 식물 정보 수정', () => {
     cy.visit('/pet/1/edit');
-    cy.wait(3000);
     cy.url().should('match', /login/);
   });
 
   it('타임라인', () => {
     cy.visit('/pet/1/timeline');
-    cy.wait(3000);
     cy.url().should('match', /login/);
   });
 });

--- a/frontend/cypress/e2e/auth.cy.ts
+++ b/frontend/cypress/e2e/auth.cy.ts
@@ -3,42 +3,42 @@ import login from '../utils/login';
 describe('비로그인 상태에서는 로그인 페이지로 이동한다.', () => {
   it('리마인더', () => {
     cy.visit('/reminder');
-    cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
+    cy.url().should('match', /login/);
   });
 
   it('내 반려 식물 목록', () => {
     cy.visit('/pet');
-    cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
+    cy.url().should('match', /login/);
   });
 
   it('반려 식물 상세 정보', () => {
     cy.visit('/pet/123');
-    cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
+    cy.url().should('match', /login/);
   });
 
   it('반려 식물 등록: 검색', () => {
     cy.visit('/pet/register');
-    cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
+    cy.url().should('match', /login/);
   });
 
   it('반려 식물 등록: 양식', () => {
     cy.visit('/pet/register/1');
-    cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
+    cy.url().should('match', /login/);
   });
 
   it('마이페이지', () => {
     cy.visit('/myPage');
-    cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
+    cy.url().should('match', /login/);
   });
 
   it('반려 식물 정보 수정', () => {
     cy.visit('/pet/1/edit');
-    cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
+    cy.url().should('match', /login/);
   });
 
   it('타임라인', () => {
     cy.visit('/pet/1/timeline');
-    cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
+    cy.url().should('match', /login/);
   });
 });
 

--- a/frontend/cypress/e2e/auth.cy.ts
+++ b/frontend/cypress/e2e/auth.cy.ts
@@ -5,37 +5,30 @@ describe('비로그인 상태에서는 로그인 페이지로 이동한다.', ()
   //   cy.visit('/reminder');
   //   cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
   // });
-
   // it('내 반려 식물 목록', () => {
   //   cy.visit('/pet');
   //   cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
   // });
-
   // it('반려 식물 상세 정보', () => {
   //   cy.visit('/pet/123');
   //   cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
   // });
-
   // it('반려 식물 등록: 검색', () => {
   //   cy.visit('/pet/register');
   //   cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
   // });
-
   // it('반려 식물 등록: 양식', () => {
   //   cy.visit('/pet/register/1');
   //   cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
   // });
-
   // it('마이페이지', () => {
   //   cy.visit('/myPage');
   //   cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
   // });
-
-  it('반려 식물 정보 수정', () => {
-    cy.visit('/pet/1/edit');
-    cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
-  });
-
+  // it('반려 식물 정보 수정', () => {
+  //   cy.visit('/pet/1/edit');
+  //   cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
+  // });
   // it('타임라인', () => {
   //   cy.visit('/pet/1/timeline');
   //   cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);

--- a/frontend/cypress/e2e/auth.cy.ts
+++ b/frontend/cypress/e2e/auth.cy.ts
@@ -1,38 +1,45 @@
 import login from '../utils/login';
 
 describe('비로그인 상태에서는 로그인 페이지로 이동한다.', () => {
-  // it('리마인더', () => {
-  //   cy.visit('/reminder');
-  //   cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
-  // });
-  // it('내 반려 식물 목록', () => {
-  //   cy.visit('/pet');
-  //   cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
-  // });
-  // it('반려 식물 상세 정보', () => {
-  //   cy.visit('/pet/123');
-  //   cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
-  // });
-  // it('반려 식물 등록: 검색', () => {
-  //   cy.visit('/pet/register');
-  //   cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
-  // });
-  // it('반려 식물 등록: 양식', () => {
-  //   cy.visit('/pet/register/1');
-  //   cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
-  // });
-  // it('마이페이지', () => {
-  //   cy.visit('/myPage');
-  //   cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
-  // });
-  // it('반려 식물 정보 수정', () => {
-  //   cy.visit('/pet/1/edit');
-  //   cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
-  // });
-  // it('타임라인', () => {
-  //   cy.visit('/pet/1/timeline');
-  //   cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
-  // });
+  it('리마인더', () => {
+    cy.visit('/reminder');
+    cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
+  });
+
+  it('내 반려 식물 목록', () => {
+    cy.visit('/pet');
+    cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
+  });
+
+  it('반려 식물 상세 정보', () => {
+    cy.visit('/pet/123');
+    cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
+  });
+
+  it('반려 식물 등록: 검색', () => {
+    cy.visit('/pet/register');
+    cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
+  });
+
+  it('반려 식물 등록: 양식', () => {
+    cy.visit('/pet/register/1');
+    cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
+  });
+
+  it('마이페이지', () => {
+    cy.visit('/myPage');
+    cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
+  });
+
+  it('반려 식물 정보 수정', () => {
+    cy.visit('/pet/1/edit');
+    cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
+  });
+
+  it('타임라인', () => {
+    cy.visit('/pet/1/timeline');
+    cy.get('#toast-root').contains('로그인 후 이용 가능').url().should('match', /login/);
+  });
 });
 
 describe('로그인 상태에서는 접근이 가능하다.', () => {

--- a/frontend/src/components/@common/Image/Image.style.ts
+++ b/frontend/src/components/@common/Image/Image.style.ts
@@ -2,7 +2,7 @@ import { keyframes, styled } from 'styled-components';
 
 export interface StyledImageProps {
   type: 'circle' | 'square' | 'wide';
-  size: string;
+  size: `${number}px`;
 }
 
 const wave = (size: string) => keyframes`

--- a/frontend/src/components/@common/Image/index.tsx
+++ b/frontend/src/components/@common/Image/index.tsx
@@ -1,16 +1,28 @@
-import { forwardRef } from 'react';
+import { forwardRef, useRef } from 'react';
 import type { StyledImageProps } from './Image.style';
 import { StyledImage } from './Image.style';
+import { getResizedImageUrl } from 'utils/image';
 import sadpiumiPng from 'assets/sadpiumi-imageFail.png';
 
 type ImageProps = Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'onError'> &
   Partial<StyledImageProps>;
 
 const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(props, ref) {
-  const { type = 'circle', size = '77px', ...imageProps } = props;
+  const { type = 'circle', size = '77px', src = sadpiumiPng, ...imageProps } = props;
+
+  const sizeValue = Number(size.slice(0, -2));
+  const fallbackImages = useRef<string[]>([
+    sadpiumiPng,
+    src,
+    getResizedImageUrl(src, sizeValue, 'png'),
+    getResizedImageUrl(src, sizeValue, 'webp'),
+  ]);
+
+  const currentImage = fallbackImages.current[fallbackImages.current.length - 1];
 
   const setErrorImage: React.ReactEventHandler<HTMLImageElement> = ({ currentTarget }) => {
-    currentTarget.src = sadpiumiPng;
+    fallbackImages.current.pop();
+    currentTarget.src = fallbackImages.current[fallbackImages.current.length - 1];
   };
 
   return (
@@ -20,6 +32,7 @@ const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(props, ref
       size={size}
       onError={setErrorImage}
       loading="lazy"
+      src={currentImage}
       {...imageProps}
     />
   );

--- a/frontend/src/components/petPlant/PetPlantCard/index.tsx
+++ b/frontend/src/components/petPlant/PetPlantCard/index.tsx
@@ -29,7 +29,7 @@ const PetPlantCard = ({
     <Wrapper>
       <CrownArea>{isBirthday && <SvgIcons icon="crown" size={64} aria-hidden />}</CrownArea>
       <ImageArea>
-        <Image src={imageUrl} type="square" size="100%" alt="반려 식물 이미지" />
+        <Image src={imageUrl} type="square" size="160px" alt="반려 식물 이미지" />
       </ImageArea>
       <ContentArea>
         <Nickname aria-label="식물 별명">{nickname} </Nickname>

--- a/frontend/src/components/search/SearchBox/index.tsx
+++ b/frontend/src/components/search/SearchBox/index.tsx
@@ -110,7 +110,7 @@ const SearchBox = (props: SearchBoxProps) => {
                     alt={name}
                     src={image}
                     type="circle"
-                    size={`calc(${height} * 2/3)`}
+                    size={`${Math.round(numberHeight * (2 / 3))}px`}
                     loading="lazy"
                   />
                   <Name>{name}</Name>

--- a/frontend/src/utils/image.ts
+++ b/frontend/src/utils/image.ts
@@ -14,3 +14,34 @@ export const getImageUrl = (file: File) => {
 
 export const isAllowedImageExtension = (file: File) =>
   ALLOWED_IMAGE_EXTENSIONS.includes(file.type.toLowerCase());
+
+const X_SMALL_WIDTH = 64;
+const SMALL_WIDTH = 256;
+
+/**
+ * 피움 서비스의 정적 이미지 파일 네이밍 정책을 따르는
+ * 알맞은 크기의 사진 url을 반환합니다.
+ *
+ * `size`가 64보다 작으면 x-small, 256보다 작으면 small 크기로 재조정된 사진 url을 반환합니다.
+ *
+ * @param url img src에 들어갈 수 있는 url. 확장자명으로 끝나야 제대로 작동합니다.
+ * @param size 사진 픽셀 크기
+ * @param extension 원하는 확장자
+ * @returns 새로운 url
+ */
+export const getResizedImageUrl = (url: string, size: number, extension: 'png' | 'webp') => {
+  const urlTokens = url.split('.');
+  const originalExtension = urlTokens.pop();
+
+  if (originalExtension === undefined) return '';
+
+  if (size < X_SMALL_WIDTH) {
+    urlTokens.push('x-small', extension);
+  } else if (size < SMALL_WIDTH) {
+    urlTokens.push('small', extension);
+  } else {
+    urlTokens.push(originalExtension);
+  }
+
+  return urlTokens.join('.');
+};


### PR DESCRIPTION
# 🔥 연관 이슈

- close #381

# 🚀 작업 내용

- [x] #384 에서 논의한 내용을 바탕으로 변환한 사진을 S3에 업로드
    - sharp 사용
    - small: 가로 256px
    - x-small: 가로 64px
- [x] 주어진 크기에 맞게 적절한 url을 찾아주는 유틸 함수
- [x] Image 컴포넌트에서 해당 url로 로딩 시도

###  사진 변환 코드 (별도의 폴더에서 따로 진행)

```js
import Sharp from 'sharp'; // 이 패키지는 npm으로 설치가 필요해요
import fs from 'fs';
import { join } from 'path';

const SMALL = {
  width: 256,
};

const X_SMALL = {
  width: 64,
};

const INPUT_DIR = './static';
const OUTPUT_DIR = './output';

const getFileNames = (dir) => fs.readdirSync(dir);

const convertImageTo = async (filename, width, type, format) => {
  const inputPath = join(INPUT_DIR, filename);
  const filenameWithoutExt = filename.split('.')[0];

  const sharp = new Sharp(inputPath);
  const { width: imageWidth } = await sharp.metadata();

  if (imageWidth <= width) {
    console.log(`${filename} image width(${imageWidth}) is smaller than target size(${width}).`);
    return false;
  }

  await sharp
    .resize(width)
    .toFormat(format.toLowerCase(), { quality: 100 })
    .toFile(join(OUTPUT_DIR, `${filenameWithoutExt}.${type}.${format.toLowerCase()}`));

  return true;
};

const filenames = getFileNames(INPUT_DIR);

filenames.forEach(async (filename) => {
  await convertImageTo(filename, SMALL.width, 'small', 'png');
  await convertImageTo(filename, SMALL.width, 'small', 'webp');
  
  await convertImageTo(filename, X_SMALL.width, 'x-small', 'png');
  await convertImageTo(filename, X_SMALL.width, 'x-small', 'webp');
});

```

# 💬 리뷰 중점사항

로직이 좀 특이합니다.

### picture / source를 안 쓴 이유

source에 webp가 들어있다고 칩시다. webp 브라우저를 지원하는 곳에서는 webp 주소로 로딩을 시도합니다.
근데 만약 저희가 S3에 해당 이미지의 webp 버전을 제공하지 않으면? 터집니다. 근데 여기서
1. onError로 src를 sadpiumiPng로 교체할 경우: sadpiumiPng가 나오고 끝
2. onError를 주지 않을 경우: 계속해서 없는 이미지 찾기 시도

이런 이지선다에 걸렸어요
제가 원하는 동작 방식은 webp 있는지 -> 없으면 png 있는지 -> 없으면 원본 -> 진짜없으면 피우미 이거였는데 source의 동작 방식은 이거랑 완전히 다르더라구요. source의 핵심은 '이게 있는가?'가 아니라 '이 확장자를 지원하는가?'여서 관심사 차이가 심해 사용하지 않는 게 오히려 구현이 편했습니다.

그래서 현재 로직은
1. 처음에 배열에 링크를 우선순위 낮은 것부터 오름차순으로 넣습니다.
2. 배열 맨 마지막 (가장 중요한) 링크로 로딩을 시도합니다
3. 실패 시 onError에서 그 다음 중요한 링크로 교체합니다.
4. 모두 실패하면 맨 마지막의 피우미가 반겨줍니다

이런 방식으로 구성을 해 놓았어요

장점은 webp를 지원하는 브라우저이고, s3에서 지원한다면 확실하게 처리가 가능합니다
단점은 s3에 없다면 webp -> png -> 원본 순서로 총 세 번의 요청을 보내야 해서 이게 과연 맞는 방법인지는 모르겠습니다
(unsplash에서 이미지를 받아오면 세 번의 요청을 해야 하는데 육안으로는 큰 차이를 느끼진 못했어요)