### PR TITLE
fix: 반려 식물 수정 시 기존 이미지 제거

### DIFF
--- a/backend/pium/src/main/java/com/official/pium/service/PetPlantService.java
+++ b/backend/pium/src/main/java/com/official/pium/service/PetPlantService.java
@@ -39,9 +39,6 @@ public class PetPlantService {
     @Value("${petPlant.image.directory}")
     private String workingDirectory;
 
-    @Value("${aws.s3.root}")
-    private String rootPath;
-
     private final PetPlantRepository petPlantRepository;
     private final DictionaryPlantRepository dictionaryPlantRepository;
     private final HistoryRepository historyRepository;
@@ -135,15 +132,8 @@ public class PetPlantService {
         if (image == null || image.isEmpty()) {
             return originalImageUrl;
         }
-        deleteImageIfExists(originalImageUrl);
+        photoManager.delete(originalImageUrl, workingDirectory);
         return photoManager.upload(image, workingDirectory);
-    }
-
-    private void deleteImageIfExists(String originalImageUrl) {
-        if (originalImageUrl.contains(rootPath + "/petPlant")) {
-            String fileName = originalImageUrl.substring(rootPath.length() - 1);
-            photoManager.delete(fileName);
-        }
     }
 
     private void publishPetPlantHistories(PetPlant petPlant, PetPlantHistory previousPetPlantHistory,

--- a/backend/pium/src/main/java/com/official/pium/service/PhotoManager.java
+++ b/backend/pium/src/main/java/com/official/pium/service/PhotoManager.java
@@ -6,5 +6,5 @@ public interface PhotoManager {
 
     String upload(MultipartFile file, String workingDirectory);
 
-    void delete(String fileName);
+    void delete(String originalImageUrl, String workingDirectory);
 }

--- a/backend/pium/src/main/java/com/official/pium/util/PhotoS3Manager.java
+++ b/backend/pium/src/main/java/com/official/pium/util/PhotoS3Manager.java
@@ -80,6 +80,6 @@ public class PhotoS3Manager implements PhotoManager {
 
     @Override
     public void delete(String fileName) {
-        s3Client.deleteObject(bucket, fileName);
+        s3Client.deleteObject(bucket, folder + directory + fileName);
     }
 }

--- a/backend/pium/src/main/java/com/official/pium/util/PhotoS3Manager.java
+++ b/backend/pium/src/main/java/com/official/pium/util/PhotoS3Manager.java
@@ -79,7 +79,10 @@ public class PhotoS3Manager implements PhotoManager {
     }
 
     @Override
-    public void delete(String fileName) {
-        s3Client.deleteObject(bucket, folder + directory + fileName);
+    public void delete(String originalImageUrl, String workingDirectory) {
+        if (originalImageUrl.contains(rootPath + SLASH + directory + workingDirectory)) {
+            String fileName = originalImageUrl.substring(rootPath.length() + 1);
+            s3Client.deleteObject(bucket, folder + fileName);
+        }
     }
 }

--- a/backend/pium/src/test/java/com/official/pium/service/PetPlantServiceTest.java
+++ b/backend/pium/src/test/java/com/official/pium/service/PetPlantServiceTest.java
@@ -227,7 +227,7 @@ class PetPlantServiceTest extends IntegrationTest {
                     .member(member)
                     .dictionaryPlant(dictionaryPlant)
                     .flowerpot("유리")
-                    .imageUrl("https://test.image.storage/petPlant/34234.jpg")
+                    .imageUrl("https://test.image.storage/test/test/34234.jpg")
                     .wind("바람이 안 통해요")
                     .light("일반 조명")
                     .lastWaterDate(LocalDate.now())

--- a/backend/pium/src/test/java/com/official/pium/util/PhotoS3ManagerTest.java
+++ b/backend/pium/src/test/java/com/official/pium/util/PhotoS3ManagerTest.java
@@ -1,6 +1,7 @@
 package com.official.pium.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
@@ -40,11 +41,5 @@ class PhotoS3ManagerTest {
         String imageUrl = photoS3Manager.upload(multipartFile, "test");
 
         assertThat(imageUrl).isNotBlank();
-    }
-
-    @Test
-    void 이미지를_삭제한다() {
-        willDoNothing().given(s3Client).deleteObject(any(), anyString());
-        Assertions.assertDoesNotThrow(() -> photoS3Manager.delete("/image.jpg"));
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #406 

# 🚀 작업 내용
반려 식물 수정 시 기존 이미지가 정상적으로 제거되도록 경로 추가했습니다. 

# 💬 리뷰 중점사항
수정하면서 테스트도 조금 보완했습니다.
혹시 더 필요한 테스트가 있으면 알려주세여~
