### PR TITLE
Fix: 로그인 되지 않던 이슈 해결

### DIFF
--- a/frontend/src/hooks/queries/auth/useLogin.ts
+++ b/frontend/src/hooks/queries/auth/useLogin.ts
@@ -1,15 +1,31 @@
 import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import useAddToast from 'hooks/@common/useAddToast';
 import AuthAPI from 'apis/auth';
 import throwOnInvalidStatus from 'utils/throwOnInvalidStatus';
+import { URL_PATH } from 'constants/index';
 
-const useLogin = () =>
-  useMutation<null, Error, string>({
+const useLogin = () => {
+  const navigation = useNavigate();
+  const addToast = useAddToast();
+
+  return useMutation<null, Error, string>({
     mutationFn: async (code: string) => {
       const response = await AuthAPI.getSessionId(code);
 
       throwOnInvalidStatus(response);
       return null;
     },
+
+    onSuccess: () => {
+      navigation(URL_PATH.reminder, { replace: true });
+    },
+
+    onError: (error) => {
+      addToast({ type: 'error', message: error.message, time: 3000 });
+      navigation(URL_PATH.login, { replace: true });
+    },
   });
+};
 
 export default useLogin;

--- a/frontend/src/pages/auth/Login/Authorization.tsx
+++ b/frontend/src/pages/auth/Login/Authorization.tsx
@@ -1,18 +1,19 @@
 import { useEffect } from 'react';
-import { Navigate, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
+import Loading from 'pages/@common/Loading';
 import useLogin from 'hooks/queries/auth/useLogin';
-import { URL_PATH } from 'constants/index';
 
 const Authorization = () => {
   const [searchParams] = useSearchParams();
   const code = searchParams.get('code');
+
   const { mutate: login } = useLogin();
 
   useEffect(() => {
     login(code ?? '');
   }, [code, login]);
 
-  return <Navigate to={URL_PATH.reminder} replace />;
+  return <Loading />;
 };
 
 export default Authorization;


### PR DESCRIPTION
# 🔥 연관 이슈

- close #431 

# 🚀 작업 내용
### 원인 
- 로그인 API method가 POST인데 tanstack-query에서는 useQuery를 사용하고 있었음
- 따라서 mutation으로 변경해서 API를 전송하도록 요청
- 그에 따라 useEffect를 통해 login메서드를 실행시킹
- 하지만 기존 Authorization 페이지에서는 바로 reminder로 이동하는 Navigator를 반환
- 즉, reminder페이지로 이동하고 로그인을 요청하는 상황이 발생해벌암;;

### 해결
- Authorization에서 Navigator를 반환하던 것을 Loading을 반환하도록 함
- 그리고 Mutation에서 SuccessCallback으로 로그인에 성공했을 경우 reminder로 navigate하도록 설정
- 반면 실패했을 때는 에러 메세지와 함께 로그인 페이지로 이동하도록 작성함.

# 💬 리뷰 중점사항

잘 부탁드립니당
