### PR TITLE
fix: 알림 등록 요청 변수명 변경 deviceToken -> token

### DIFF
--- a/backend/pium/src/main/java/com/official/pium/service/MemberService.java
+++ b/backend/pium/src/main/java/com/official/pium/service/MemberService.java
@@ -47,7 +47,7 @@ public class MemberService {
         if (member.isSubscribe()) {
             throw new IllegalArgumentException("이미 알림을 구독하고 있습니다.");
         }
-        member.updateDeviceToken(request.getDeviceToken());
+        member.updateDeviceToken(request.getToken());
     }
 
     @Transactional

--- a/backend/pium/src/main/java/com/official/pium/service/dto/NotificationSubscribeRequest.java
+++ b/backend/pium/src/main/java/com/official/pium/service/dto/NotificationSubscribeRequest.java
@@ -15,5 +15,5 @@ import lombok.NoArgsConstructor;
 public class NotificationSubscribeRequest {
 
     @NotNull
-    private String deviceToken;
+    private String token;
 }

--- a/backend/pium/src/test/java/com/official/pium/controller/MemberControllerTest.java
+++ b/backend/pium/src/test/java/com/official/pium/controller/MemberControllerTest.java
@@ -135,7 +135,7 @@ class MemberControllerTest extends UITest {
                             .session(session)
                             .contentType(MediaType.APPLICATION_JSON_VALUE)
                             .content(objectMapper.writeValueAsString(NotificationSubscribeRequest.builder()
-                                    .deviceToken("deviceToken")
+                                    .token("deviceToken")
                                     .build())))
                     .andDo(document("member/subscribeNotification/",
                                     preprocessRequest(prettyPrint()),

--- a/backend/pium/src/test/java/com/official/pium/service/MemberServiceTest.java
+++ b/backend/pium/src/test/java/com/official/pium/service/MemberServiceTest.java
@@ -77,7 +77,7 @@ class MemberServiceTest {
                 .build();
 
         memberService.subscribeNotification(saveMember, NotificationSubscribeRequest.builder()
-                .deviceToken("deviceToken")
+                .token("deviceToken")
                 .build());
 
         assertThat(saveMember.getDeviceToken()).isEqualTo("deviceToken");
@@ -102,7 +102,7 @@ class MemberServiceTest {
                 .deviceToken("deviceToken")
                 .build();
         NotificationSubscribeRequest request = NotificationSubscribeRequest.builder()
-                .deviceToken("deviceToken")
+                .token("deviceToken")
                 .build();
 
         Assertions.assertThatThrownBy(() -> {


### PR DESCRIPTION
# 🔥 연관 이슈

- close #439 

# 🚀 작업 내용

- [x] `POST /notification` 요청 시 json 변수명 변경 `deviceToken` -> `token`


# 💬 리뷰 중점사항
죄송합니다 22..
