### PR TITLE
fix: 요청 발생 시 HttpSession 제거하도록 변경

### DIFF
--- a/backend/pium/src/main/java/com/official/pium/controller/AuthController.java
+++ b/backend/pium/src/main/java/com/official/pium/controller/AuthController.java
@@ -20,7 +20,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private static final String SESSION_KEY = "KAKAO_ID";
-    private static final int SESSION_EXPIRE_SECOND = 86400 * 30;
 
     private final AuthService authService;
     private final SessionGroupService sessionGroupService;
@@ -32,7 +31,6 @@ public class AuthController {
         Member loginMember = authService.login(code);
 
         HttpSession session = request.getSession();
-        session.setMaxInactiveInterval(SESSION_EXPIRE_SECOND);
         sessionGroupService.add(session.getId(), SESSION_KEY, loginMember.getKakaoId().toString());
         return ResponseEntity.ok().build();
     }

--- a/backend/pium/src/main/java/com/official/pium/controller/MemberArgumentResolver.java
+++ b/backend/pium/src/main/java/com/official/pium/controller/MemberArgumentResolver.java
@@ -5,8 +5,6 @@ import com.official.pium.domain.Member;
 import com.official.pium.exception.AuthenticationException;
 import com.official.pium.repository.MemberRepository;
 import com.official.pium.service.SessionGroupService;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -17,7 +15,11 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @RequiredArgsConstructor
 public class MemberArgumentResolver implements HandlerMethodArgumentResolver {
 
+    private static final int VALUE_INDEX = 1;
+    private static final String SESSION_DELIMITER = "=";
     private static final String SESSION_KEY = "KAKAO_ID";
+    private static final String COOKIE_HEADER = "cookie";
+    private static final int MIN_SESSION_SIZE = 2;
 
     private final MemberRepository memberRepository;
     private final SessionGroupService sessionGroupService;
@@ -31,14 +33,7 @@ public class MemberArgumentResolver implements HandlerMethodArgumentResolver {
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory)
             throws AuthenticationException {
-        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
-        HttpSession session = request.getSession(false);
-
-        if (session == null) {
-            throw new AuthenticationException("로그인이 필요합니다");
-        }
-
-        String sessionValue = sessionGroupService.findOrExtendsBySessionIdAndKey(session.getId(), SESSION_KEY);
+        String sessionValue = getSessionId(webRequest);
         try {
             Long kakaoId = Long.valueOf(sessionValue);
             return memberRepository.findByKakaoId(kakaoId)
@@ -46,5 +41,22 @@ public class MemberArgumentResolver implements HandlerMethodArgumentResolver {
         } catch (NumberFormatException e) {
             throw new AuthenticationException("잘못된 세션 정보로 인해 사용자 인증에 실패하였습니다.");
         }
+    }
+
+    private String getSessionId(NativeWebRequest webRequest) {
+        String sessionCookie = webRequest.getHeader(COOKIE_HEADER);
+        String sessionId = parseSessionCookie(sessionCookie);
+        return sessionGroupService.findOrExtendsBySessionIdAndKey(sessionId, SESSION_KEY);
+    }
+
+    private String parseSessionCookie(String sessionCookie) {
+        if (sessionCookie == null || sessionCookie.isBlank()) {
+            return null;
+        }
+        String[] keyAndValue = sessionCookie.split(SESSION_DELIMITER);
+        if (keyAndValue.length < MIN_SESSION_SIZE) {
+            return null;
+        }
+        return keyAndValue[VALUE_INDEX];
     }
 }

--- a/backend/pium/src/test/java/com/official/pium/UITest.java
+++ b/backend/pium/src/test/java/com/official/pium/UITest.java
@@ -1,5 +1,6 @@
 package com.official.pium;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -41,7 +42,7 @@ public class UITest {
         admin = new Admin("admin", "1234", "12345");
 
         session.setAttribute(ADMIN_SESSION_KEY, admin);
-        given(sessionGroupService.findOrExtendsBySessionIdAndKey(anyString(), anyString()))
+        given(sessionGroupService.findOrExtendsBySessionIdAndKey(any(), anyString()))
                 .willReturn("12345");
         given(memberRepository.findByKakaoId(anyLong()))
                 .willReturn(Optional.of(member));

--- a/backend/pium/src/test/java/com/official/pium/acceptance/GardenApiTest.java
+++ b/backend/pium/src/test/java/com/official/pium/acceptance/GardenApiTest.java
@@ -45,7 +45,7 @@ class GardenApiTest extends AcceptanceTest {
                     .then()
                     .log().all()
                     .statusCode(HttpStatus.UNAUTHORIZED.value())
-                    .assertThat().body("message", containsString("로그인이 필요합니다"));
+                    .assertThat().body("message", containsString("일치하는 세션을 찾을 수 없습니다."));
         }
 
         @Test
@@ -177,7 +177,8 @@ class GardenApiTest extends AcceptanceTest {
                     .statusCode(HttpStatus.OK.value())
                     .extract();
 
-            List<SingleGardenResponse> singleGardenResponses = response.jsonPath().getList("data", SingleGardenResponse.class);
+            List<SingleGardenResponse> singleGardenResponses = response.jsonPath()
+                    .getList("data", SingleGardenResponse.class);
 
             assertSoftly(
                     softly -> {

--- a/backend/pium/src/test/java/com/official/pium/acceptance/HistoryApiTest.java
+++ b/backend/pium/src/test/java/com/official/pium/acceptance/HistoryApiTest.java
@@ -51,7 +51,7 @@ class HistoryApiTest extends AcceptanceTest {
                     .then()
                     .log().all()
                     .statusCode(HttpStatus.UNAUTHORIZED.value())
-                    .assertThat().body("message", containsString("로그인이 필요합니다"));
+                    .assertThat().body("message", containsString("일치하는 세션을 찾을 수 없습니다."));
         }
 
         @Test

--- a/backend/pium/src/test/java/com/official/pium/acceptance/PetPlantApiTest.java
+++ b/backend/pium/src/test/java/com/official/pium/acceptance/PetPlantApiTest.java
@@ -54,7 +54,7 @@ class PetPlantApiTest extends AcceptanceTest {
                     .then()
                     .log().all()
                     .statusCode(HttpStatus.UNAUTHORIZED.value())
-                    .assertThat().body("message", containsString("로그인이 필요합니다"));
+                    .assertThat().body("message", containsString("일치하는 세션을 찾을 수 없습니다."));
         }
 
         @Test
@@ -185,7 +185,7 @@ class PetPlantApiTest extends AcceptanceTest {
                     .then()
                     .log().all()
                     .statusCode(HttpStatus.UNAUTHORIZED.value())
-                    .assertThat().body("message", containsString("로그인이 필요합니다"));
+                    .assertThat().body("message", containsString("일치하는 세션을 찾을 수 없습니다."));
         }
 
         @Test
@@ -345,7 +345,7 @@ class PetPlantApiTest extends AcceptanceTest {
                     .then()
                     .log().all()
                     .statusCode(HttpStatus.UNAUTHORIZED.value())
-                    .assertThat().body("message", containsString("로그인이 필요합니다"));
+                    .assertThat().body("message", containsString("일치하는 세션을 찾을 수 없습니다."));
         }
 
         @Test
@@ -422,7 +422,7 @@ class PetPlantApiTest extends AcceptanceTest {
                     .then()
                     .log().all()
                     .statusCode(HttpStatus.UNAUTHORIZED.value())
-                    .assertThat().body("message", containsString("로그인이 필요합니다"));
+                    .assertThat().body("message", containsString("일치하는 세션을 찾을 수 없습니다."));
         }
 
         @Test
@@ -723,7 +723,7 @@ class PetPlantApiTest extends AcceptanceTest {
                     .then()
                     .log().all()
                     .statusCode(HttpStatus.UNAUTHORIZED.value())
-                    .assertThat().body("message", containsString("로그인이 필요합니다"));
+                    .assertThat().body("message", containsString("일치하는 세션을 찾을 수 없습니다."));
         }
 
         @Test

--- a/backend/pium/src/test/java/com/official/pium/acceptance/ReminderApiTest.java
+++ b/backend/pium/src/test/java/com/official/pium/acceptance/ReminderApiTest.java
@@ -49,7 +49,7 @@ class ReminderApiTest extends AcceptanceTest {
                     .then()
                     .log().all()
                     .statusCode(HttpStatus.UNAUTHORIZED.value())
-                    .assertThat().body("message", containsString("로그인이 필요합니다"));
+                    .assertThat().body("message", containsString("일치하는 세션을 찾을 수 없습니다."));
         }
 
         @Test
@@ -119,7 +119,7 @@ class ReminderApiTest extends AcceptanceTest {
                     .then()
                     .log().all()
                     .statusCode(HttpStatus.UNAUTHORIZED.value())
-                    .assertThat().body("message", containsString("로그인이 필요합니다"));
+                    .assertThat().body("message", containsString("일치하는 세션을 찾을 수 없습니다."));
         }
 
         @Test
@@ -327,7 +327,7 @@ class ReminderApiTest extends AcceptanceTest {
                     .then()
                     .log().all()
                     .statusCode(HttpStatus.UNAUTHORIZED.value())
-                    .assertThat().body("message", containsString("로그인이 필요합니다"));
+                    .assertThat().body("message", containsString("일치하는 세션을 찾을 수 없습니다."));
         }
 
         @Test

--- a/backend/pium/src/test/java/com/official/pium/controller/AuthControllerTest.java
+++ b/backend/pium/src/test/java/com/official/pium/controller/AuthControllerTest.java
@@ -1,5 +1,6 @@
 package com.official.pium.controller;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -17,6 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.official.pium.UITest;
 import com.official.pium.domain.Member;
+import com.official.pium.exception.AuthenticationException;
 import com.official.pium.service.AuthService;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -27,7 +29,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -94,23 +95,25 @@ class AuthControllerTest extends UITest {
 
         @Test
         void 세션_정보_없이_요청_시_401_반환() throws Exception {
+            given(sessionGroupService.findOrExtendsBySessionIdAndKey(any(), anyString()))
+                    .willThrow(new AuthenticationException("일치하는 세션을 찾을 수 없습니다."));
+            
             mockMvc.perform(post("/logout")
                             .contentType(APPLICATION_JSON_VALUE))
                     .andExpect(status().isUnauthorized())
-                    .andExpect(jsonPath("$.message").value("로그인이 필요합니다"))
+                    .andExpect(jsonPath("$.message").value("일치하는 세션을 찾을 수 없습니다."))
                     .andDo(print());
         }
 
         @Test
         void 만료된_세션으로_요청_시_401_반환() throws Exception {
-            MockHttpSession expiredSession = new MockHttpSession();
-            expiredSession.invalidate();
+            given(sessionGroupService.findOrExtendsBySessionIdAndKey(any(), anyString()))
+                    .willThrow(new AuthenticationException("일치하는 세션을 찾을 수 없습니다."));
 
             mockMvc.perform(post("/logout")
-                            .session(expiredSession)
                             .contentType(APPLICATION_JSON_VALUE))
                     .andExpect(status().isUnauthorized())
-                    .andExpect(jsonPath("$.message").value("로그인이 필요합니다"))
+                    .andExpect(jsonPath("$.message").value("일치하는 세션을 찾을 수 없습니다."))
                     .andDo(print());
         }
     }

--- a/backend/pium/src/test/java/com/official/pium/controller/GardenControllerTest.java
+++ b/backend/pium/src/test/java/com/official/pium/controller/GardenControllerTest.java
@@ -3,6 +3,7 @@ package com.official.pium.controller;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
@@ -21,6 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.official.pium.UITest;
 import com.official.pium.domain.Member;
+import com.official.pium.exception.AuthenticationException;
 import com.official.pium.fixture.GardenFixture;
 import com.official.pium.fixture.GardenFixture.REQUEST;
 import com.official.pium.service.GardenService;
@@ -86,6 +88,8 @@ public class GardenControllerTest extends UITest {
         void 로그인_없이_요청하면_401_반환() throws Exception {
             willDoNothing().given(gardenService)
                     .create(any(GardenCreateRequest.class), any(Member.class));
+            given(sessionGroupService.findOrExtendsBySessionIdAndKey(any(), anyString()))
+                    .willThrow(new AuthenticationException("일치하는 세션을 찾을 수 없습니다."));
 
             mockMvc.perform(post("/garden")
                             .content(objectMapper.writeValueAsString(REQUEST.정원_게시글_등록_요청))


### PR DESCRIPTION
# 🔥 연관 이슈

- close #452 

# 🚀 작업 내용

ArgumentResolver에서 HttpSession을 통해 sessionId를 가져오는 것을, 최초의 request인 NativeRequest에서 가져오도록 변경했습니다.

# 💬 리뷰 중점사항
쿠키에서 세션 ID를 파싱하고 있는데 해당 로직 한번 확인해주세요 !