### PR TITLE
fix: 메모리 세션 구문 제거

### DIFF
--- a/backend/pium/src/main/java/com/official/pium/controller/AuthController.java
+++ b/backend/pium/src/main/java/com/official/pium/controller/AuthController.java
@@ -36,14 +36,8 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(HttpServletRequest request, @Auth Member member) {
-        HttpSession session = request.getSession(false);
-
-        if (session != null) {
-            sessionGroupService.delete(session.getId(), SESSION_KEY);
-            session.invalidate();
-        }
-
+    public ResponseEntity<Void> logout(@Auth Member member) {
+        sessionGroupService.delete(member.getKakaoId());
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/pium/src/main/java/com/official/pium/controller/MemberController.java
+++ b/backend/pium/src/main/java/com/official/pium/controller/MemberController.java
@@ -30,24 +30,12 @@ public class MemberController {
 
     @DeleteMapping("/withdraw")
     public ResponseEntity<Void> withdraw(HttpServletRequest request, @Auth Member member) {
-        HttpSession session = request.getSession(false);
-
-        if (session != null) {
-            session.invalidate();
-        }
         memberService.withdraw(member);
-
         return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/me")
-    public ResponseEntity<Void> checkSessionStatus(HttpServletRequest request, @Auth Member member) {
-        HttpSession session = request.getSession(false);
-
-        if (session == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
-
+    public ResponseEntity<Void> checkSessionStatus(@Auth Member member) {
         return ResponseEntity.ok().build();
     }
 

--- a/backend/pium/src/main/java/com/official/pium/exception/AuthorizationException.java
+++ b/backend/pium/src/main/java/com/official/pium/exception/AuthorizationException.java
@@ -12,10 +12,6 @@ public class AuthorizationException extends RuntimeException {
 
     public static class NeedAdminException extends AuthorizationException {
 
-        public NeedAdminException() {
-            super();
-        }
-
         public NeedAdminException(final String message) {
             super(message);
         }

--- a/backend/pium/src/main/java/com/official/pium/repository/SessionGroupRepository.java
+++ b/backend/pium/src/main/java/com/official/pium/repository/SessionGroupRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface SessionGroupRepository extends JpaRepository<SessionGroup, Long> {
 
     Optional<SessionGroup> findBySessionIdAndSessionKey(String sessionId, String sessionKey);
+
+    void deleteBySessionValue(String sessionValue);
 }

--- a/backend/pium/src/main/java/com/official/pium/service/MemberService.java
+++ b/backend/pium/src/main/java/com/official/pium/service/MemberService.java
@@ -5,6 +5,7 @@ import com.official.pium.domain.PetPlant;
 import com.official.pium.repository.HistoryRepository;
 import com.official.pium.repository.MemberRepository;
 import com.official.pium.repository.PetPlantRepository;
+import com.official.pium.repository.SessionGroupRepository;
 import com.official.pium.service.dto.NotificationCheckResponse;
 import com.official.pium.service.dto.NotificationSubscribeRequest;
 import com.official.pium.service.dto.OAuthProvider;
@@ -21,6 +22,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final HistoryRepository historyRepository;
     private final PetPlantRepository petPlantRepository;
+    private final SessionGroupRepository sessionGroupRepository;
     private final OAuthProvider provider;
 
     @Transactional
@@ -33,6 +35,7 @@ public class MemberService {
 
         petPlantRepository.deleteAllByMember(member);
 
+        sessionGroupRepository.deleteBySessionValue(String.valueOf(member.getKakaoId()));
         memberRepository.deleteById(member.getId());
     }
 

--- a/backend/pium/src/main/java/com/official/pium/service/SessionGroupService.java
+++ b/backend/pium/src/main/java/com/official/pium/service/SessionGroupService.java
@@ -66,4 +66,9 @@ public class SessionGroupService {
 
         sessionGroupRepository.delete(sessionGroup);
     }
+
+    @Transactional
+    public void delete(Long kakaoId) {
+        sessionGroupRepository.deleteBySessionValue(String.valueOf(kakaoId));
+    }
 }

--- a/backend/pium/src/test/java/com/official/pium/controller/MemberControllerTest.java
+++ b/backend/pium/src/test/java/com/official/pium/controller/MemberControllerTest.java
@@ -101,11 +101,10 @@ class MemberControllerTest extends UITest {
 
         @Test
         void 유효하지_않은_상태라면_401_반환() throws Exception {
-            MockHttpSession expiredSession = new MockHttpSession();
-            expiredSession.invalidate();
+            given(sessionGroupService.findOrExtendsBySessionIdAndKey(any(), anyString()))
+                    .willThrow(new AuthenticationException("일치하는 세션을 찾을 수 없습니다."));
 
             mockMvc.perform(get("/members/me")
-                            .session(expiredSession)
                             .contentType(MediaType.APPLICATION_JSON_VALUE))
                     .andExpect(status().isUnauthorized())
                     .andDo(print());


### PR DESCRIPTION
# 🔥 연관 이슈

- close #454 

# 🚀 작업 내용

`/members/me`, `/logout`, `/withdraw` 등 사용자 세션을 다루는 API에서 WAS Session을 사용하는 구문을 제거했습니다.

# 💬 리뷰 중점사항

감사합니다.