### PR TITLE
fix: 로그인 시 세션이 존재할 경우 정상 반환

### DIFF
--- a/backend/pium/src/main/java/com/official/pium/repository/SessionGroupRepository.java
+++ b/backend/pium/src/main/java/com/official/pium/repository/SessionGroupRepository.java
@@ -9,4 +9,6 @@ public interface SessionGroupRepository extends JpaRepository<SessionGroup, Long
     Optional<SessionGroup> findBySessionIdAndSessionKey(String sessionId, String sessionKey);
 
     void deleteBySessionValue(String sessionValue);
+
+    boolean existsBySessionIdAndSessionKey(String sessionId, String key);
 }

--- a/backend/pium/src/main/java/com/official/pium/service/SessionGroupService.java
+++ b/backend/pium/src/main/java/com/official/pium/service/SessionGroupService.java
@@ -45,10 +45,9 @@ public class SessionGroupService {
 
     @Transactional
     public void add(String sessionId, String key, String value) {
-        sessionGroupRepository.findBySessionIdAndSessionKey(sessionId, key)
-                .ifPresent(existsSessionGroup -> {
-                    throw new AuthenticationException("이미 존재하는 세션입니다. sessionId: " + sessionId);
-                });
+        if (sessionGroupRepository.existsBySessionIdAndSessionKey(sessionId, key)) {
+            return;
+        }
 
         SessionGroup sessionGroup = SessionGroup.builder()
                 .sessionId(sessionId)

--- a/backend/pium/src/test/java/com/official/pium/repository/SessionGroupRepositoryTest.java
+++ b/backend/pium/src/test/java/com/official/pium/repository/SessionGroupRepositoryTest.java
@@ -1,15 +1,16 @@
 package com.official.pium.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.official.pium.RepositoryTest;
 import com.official.pium.domain.SessionGroup;
-import java.time.LocalDateTime;
-import java.util.UUID;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
@@ -79,5 +80,32 @@ class SessionGroupRepositoryTest extends RepositoryTest {
         sessionGroupRepository.delete(savedSessionGroup);
 
         assertThat(sessionGroupRepository.findById(savedSessionGroup.getId())).isEmpty();
+    }
+
+    @Test
+    void 기존_세션이_존재하면_True() {
+        SessionGroup sessionGroup = SessionGroup.builder()
+                .sessionId("UUID.randomUUID().toString()")
+                .sessionKey("KAKAO_ID")
+                .sessionValue("1234546426")
+                .expireTime(LocalDateTime.now().plusMinutes(30))
+                .build();
+        SessionGroup savedSessionGroup = sessionGroupRepository.save(sessionGroup);
+
+        boolean existsBySessionIdAndSessionKey = sessionGroupRepository.existsBySessionIdAndSessionKey(
+                savedSessionGroup.getSessionId(),
+                savedSessionGroup.getSessionKey()
+        );
+
+        assertThat(existsBySessionIdAndSessionKey).isTrue();
+    }
+
+    @Test
+    void 기존_세션이_존재하지않으면_False() {
+        boolean existsBySessionIdAndSessionKey = sessionGroupRepository.existsBySessionIdAndSessionKey(
+                "id", "sessionKey"
+        );
+
+        assertThat(existsBySessionIdAndSessionKey).isFalse();
     }
 }

--- a/backend/pium/src/test/java/com/official/pium/service/SessionGroupServiceTest.java
+++ b/backend/pium/src/test/java/com/official/pium/service/SessionGroupServiceTest.java
@@ -138,19 +138,6 @@ class SessionGroupServiceTest extends IntegrationTest {
 
             assertThat(sessionGroupRepository.findBySessionIdAndSessionKey(sessionId, sessionKey)).isPresent();
         }
-
-        @Test
-        void 동일한_세션_그룹이_존재하면_예외가_발생한다() {
-            SessionGroup sessionGroup = sessionGroupSupport.builder().build();
-
-            assertThatThrownBy(() -> sessionGroupService.add(
-                    sessionGroup.getSessionId(),
-                    sessionGroup.getSessionKey(),
-                    sessionGroup.getSessionValue()
-            ))
-                    .isInstanceOf(AuthenticationException.class)
-                    .hasMessage("이미 존재하는 세션입니다. sessionId: " + sessionGroup.getSessionId());
-        }
     }
 
     @Nested


### PR DESCRIPTION
# 🔥 연관 이슈

- close #460 

# 🚀 작업 내용

로그인 시 세션이 존재할 경우 예외를 던지는것이 아니라 정상 반환하도록 수정했습니다.

# 💬 리뷰 중점사항
