### PR TITLE
fix: 이벤트 리스터 인자 타입 수정

### DIFF
--- a/backend/pium/src/main/java/com/official/pium/notification/application/NotificationEventListener.java
+++ b/backend/pium/src/main/java/com/official/pium/notification/application/NotificationEventListener.java
@@ -1,10 +1,10 @@
 package com.official.pium.notification.application;
 
 import com.official.pium.petPlant.event.notification.NotificationEvent;
-import java.util.List;
+import com.official.pium.petPlant.event.notification.NotificationEvents;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.*;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -15,8 +15,8 @@ public class NotificationEventListener {
 
     @EventListener
     @Async
-    public void handleNotificationEvents(List<NotificationEvent> notificationEvent) {
-        for (NotificationEvent event : notificationEvent) {
+    public void handleNotificationEvents(NotificationEvents notificationEvents) {
+        for (NotificationEvent event : notificationEvents.getNotificationEvents()) {
             notificationService.sendNotification(event.getDeviceToken(), event.getTitle(), event.getBody());
         }
     }

--- a/backend/pium/src/main/java/com/official/pium/petPlant/application/ReminderService.java
+++ b/backend/pium/src/main/java/com/official/pium/petPlant/application/ReminderService.java
@@ -9,6 +9,7 @@ import com.official.pium.petPlant.application.dto.ReminderUpdateRequest;
 import com.official.pium.petPlant.domain.PetPlant;
 import com.official.pium.petPlant.event.history.HistoryEvent;
 import com.official.pium.petPlant.event.notification.NotificationEvent;
+import com.official.pium.petPlant.event.notification.NotificationEvents;
 import com.official.pium.petPlant.repository.PetPlantRepository;
 import java.time.LocalDate;
 import java.util.List;
@@ -88,7 +89,7 @@ public class ReminderService {
                         .build()
                 ).toList();
 
-        publisher.publishEvent(events);
+        publisher.publishEvent(NotificationEvents.from(events));
     }
 
     public void sendWaterNotificationTest() {
@@ -101,6 +102,6 @@ public class ReminderService {
                         .build()
                 ).toList();
 
-        publisher.publishEvent(events);
+        publisher.publishEvent(NotificationEvents.from(events));
     }
 }

--- a/backend/pium/src/main/java/com/official/pium/petPlant/event/notification/NotificationEvents.java
+++ b/backend/pium/src/main/java/com/official/pium/petPlant/event/notification/NotificationEvents.java
@@ -1,0 +1,17 @@
+package com.official.pium.petPlant.event.notification;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class NotificationEvents {
+
+    private final List<NotificationEvent> notificationEvents;
+
+    public static NotificationEvents from(List<NotificationEvent> notificationEvents) {
+        return new NotificationEvents(notificationEvents);
+    }
+}


### PR DESCRIPTION
 **※ 해당 PR 및 커밋은 이건회(@rawfishthelgh )와 함께 몹 프로그래밍으로 작성했습니다**

# 🔥 연관 이슈

- close #488 

# 🚀 작업 내용

알림 전송 이벤트 리스너의 타입을 `List<NotificationEvent>` -> `NotificationEvents` 로 변경

아마 히스토리 할 때 겪었던 이슈 같은데 기억나시는 분도 있을 것 같네요 😭

# 💬 리뷰 중점사항

이벤트 리스터 파라미터 변경된 부분과 이벤트 호출하는(reminderService) 확인해주시면 됩니다 !