### PR TITLE
refactor: fcm 서버 비동기 처리 구현

### DIFF
--- a/backend/pium/src/main/java/com/official/pium/admin/service/TestService.java
+++ b/backend/pium/src/main/java/com/official/pium/admin/service/TestService.java
@@ -34,7 +34,7 @@ public class TestService {
 //    }
 
     public void sendWaterNotificationAsyncRampTest() {
-        List<PetPlant> petPlants = petPlantRepository.findAllByMemberId(6L);
+        List<PetPlant> petPlants = petPlantRepository.findAllByMemberId(7L);
 //        List<NotificationEvent> events = petPlants.stream()
 //                .map(plant -> NotificationEvent.builder()
 //                        .title(plant.getNickname())
@@ -61,7 +61,7 @@ public class TestService {
     }
 
     public void sendWaterNotificationAsyncTest() {
-        List<PetPlant> petPlants = petPlantRepository.findAllByMemberId(6L);
+        List<PetPlant> petPlants = petPlantRepository.findAllByMemberId(7L);
         List<NotificationEvent> events = petPlants.stream()
                 .map(plant -> NotificationEvent.builder()
                         .title(plant.getNickname())

--- a/backend/pium/src/main/java/com/official/pium/admin/service/TestService.java
+++ b/backend/pium/src/main/java/com/official/pium/admin/service/TestService.java
@@ -1,9 +1,6 @@
 package com.official.pium.admin.service;
 
-import com.official.pium.petPlant.domain.PetPlant;
-import com.official.pium.petPlant.event.notification.NotificationEvent;
 import com.official.pium.petPlant.repository.PetPlantRepository;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -33,8 +30,8 @@ public class TestService {
 //        log.info("동기 알림 테스트 종료. Thread: " + Thread.currentThread().getId() + " " + Thread.currentThread().getName());
 //    }
 
-    public void sendWaterNotificationAsyncRampTest() {
-        List<PetPlant> petPlants = petPlantRepository.findAllByMemberId(7L);
+//    public void sendWaterNotificationAsyncRampTest() {
+//        List<PetPlant> petPlants = petPlantRepository.findAllByMemberId(7L);
 //        List<NotificationEvent> events = petPlants.stream()
 //                .map(plant -> NotificationEvent.builder()
 //                        .title(plant.getNickname())
@@ -43,39 +40,39 @@ public class TestService {
 //                        .build()
 //                ).toList();
 
-        for (int i = 0; i < 100; i++) {
-            PetPlant petPlant = petPlants.get(i);
-            NotificationEvent event = NotificationEvent.builder()
-                    .title(petPlant.getNickname())
-                    .body("물줘")
-                    .deviceToken(petPlant.getMember().getDeviceToken())
-                    .build();
-            publisher.publishEvent(event);
-        }
+//        for (int i = 0; i < 100; i++) {
+//            PetPlant petPlant = petPlants.get(i);
+//            NotificationEvent event = NotificationEvent.builder()
+//                    .title(petPlant.getNickname())
+//                    .body("물줘")
+//                    .deviceToken(petPlant.getMember().getDeviceToken())
+//                    .build();
+//            publisher.publishEvent(event);
+//        }
 
 //        log.info("비동기 테스트 램프업 시작");
 //        for (int i = 0; i < 100; i++) {
 //            NotificationEvent notificationEvent = events.get(i);
 //            publisher.publishEvent(notificationEvent);
 //        }
-    }
+//    }
 
-    public void sendWaterNotificationAsyncTest() {
-        List<PetPlant> petPlants = petPlantRepository.findAllByMemberId(7L);
-        List<NotificationEvent> events = petPlants.stream()
-                .map(plant -> NotificationEvent.builder()
-                        .title(plant.getNickname())
-                        .body("(테스트 중) 물을 줄 시간이에요!")
-                        .deviceToken(plant.getMember().getDeviceToken())
-                        .build()
-                ).toList();
-
-        int i = 1;
-        log.info("비동기 알림 테스트 시작. Thread: " + Thread.currentThread().getId() + " " + Thread.currentThread().getName());
-        for (NotificationEvent event : events) {
-            log.info(i++ + "번째 알림 이벤트");
-            publisher.publishEvent(event);
-        }
-        log.info("비동기 알림 테스트 종료. Thread: " + Thread.currentThread().getId() + " " + Thread.currentThread().getName());
-    }
+//    public void sendWaterNotificationAsyncTest() {
+//        List<PetPlant> petPlants = petPlantRepository.findAllByMemberId(7L);
+//        List<NotificationEvent> events = petPlants.stream()
+//                .map(plant -> NotificationEvent.builder()
+//                        .title(plant.getNickname())
+//                        .body("(테스트 중) 물을 줄 시간이에요!")
+//                        .deviceToken(plant.getMember().getDeviceToken())
+//                        .build()
+//                ).toList();
+//
+//        int i = 1;
+//        log.info("비동기 알림 테스트 시작. Thread: " + Thread.currentThread().getId() + " " + Thread.currentThread().getName());
+//        for (NotificationEvent event : events) {
+//            log.info(i++ + "번째 알림 이벤트");
+//            publisher.publishEvent(event);
+//        }
+//        log.info("비동기 알림 테스트 종료. Thread: " + Thread.currentThread().getId() + " " + Thread.currentThread().getName());
+//    }
 }

--- a/backend/pium/src/main/java/com/official/pium/admin/ui/TestController.java
+++ b/backend/pium/src/main/java/com/official/pium/admin/ui/TestController.java
@@ -1,6 +1,9 @@
 package com.official.pium.admin.ui;
 
+import com.official.pium.admin.service.TestService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -9,23 +12,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/test")
 public class TestController {
 
-//    private final TestService testService;
+    private final TestService testService;
 
-//    @GetMapping("/notifications")
-//    public ResponseEntity<String> notificationTest() {
-//        testService.sendWaterNotificationTest();
-//        return ResponseEntity.ok("알림 기능 테스트 성공");
-//    }
+    @GetMapping("/notifications/ramp")
+    public ResponseEntity<String> notificationRampTest() {
+        testService.sendWaterNotificationAsyncRampTest();
+        return ResponseEntity.ok("비동기 알림 기능 테스트 램프업 성공");
+    }
 
-//    @GetMapping("/notifications/ramp")
-//    public ResponseEntity<String> notificationRampTest() {
-//        testService.sendWaterNotificationAsyncRampTest();
-//        return ResponseEntity.ok("비동기 알림 기능 테스트 램프업 성공");
-//    }
-//
-//    @GetMapping("/notifications/async")
-//    public ResponseEntity<String> notificationAsyncTest() {
-//        testService.sendWaterNotificationAsyncTest();
-//        return ResponseEntity.ok("비동기 알림 기능 테스트 성공");
-//    }
+    @GetMapping("/notifications/async")
+    public ResponseEntity<String> notificationAsyncTest() {
+        testService.sendWaterNotificationAsyncTest();
+        return ResponseEntity.ok("비동기 알림 기능 테스트 성공");
+    }
 }

--- a/backend/pium/src/main/java/com/official/pium/admin/ui/TestController.java
+++ b/backend/pium/src/main/java/com/official/pium/admin/ui/TestController.java
@@ -2,8 +2,6 @@ package com.official.pium.admin.ui;
 
 import com.official.pium.admin.service.TestService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,15 +12,15 @@ public class TestController {
 
     private final TestService testService;
 
-    @GetMapping("/notifications/ramp")
-    public ResponseEntity<String> notificationRampTest() {
-        testService.sendWaterNotificationAsyncRampTest();
-        return ResponseEntity.ok("비동기 알림 기능 테스트 램프업 성공");
-    }
-
-    @GetMapping("/notifications/async")
-    public ResponseEntity<String> notificationAsyncTest() {
-        testService.sendWaterNotificationAsyncTest();
-        return ResponseEntity.ok("비동기 알림 기능 테스트 성공");
-    }
+//    @GetMapping("/notifications/ramp")
+//    public ResponseEntity<String> notificationRampTest() {
+//        testService.sendWaterNotificationAsyncRampTest();
+//        return ResponseEntity.ok("비동기 알림 기능 테스트 램프업 성공");
+//    }
+//
+//    @GetMapping("/notifications/async")
+//    public ResponseEntity<String> notificationAsyncTest() {
+//        testService.sendWaterNotificationAsyncTest();
+//        return ResponseEntity.ok("비동기 알림 기능 테스트 성공");
+//    }
 }

--- a/backend/pium/src/main/java/com/official/pium/config/AsyncConfig.java
+++ b/backend/pium/src/main/java/com/official/pium/config/AsyncConfig.java
@@ -13,7 +13,7 @@ public class AsyncConfig implements AsyncConfigurer {
     @Override
     public Executor getAsyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(20);
+        executor.setCorePoolSize(40);
         executor.setThreadNamePrefix("2024-Pium-Thread: ");
         executor.initialize();
         return executor;

--- a/backend/pium/src/main/java/com/official/pium/config/AsyncConfig.java
+++ b/backend/pium/src/main/java/com/official/pium/config/AsyncConfig.java
@@ -13,7 +13,7 @@ public class AsyncConfig implements AsyncConfigurer {
     @Override
     public Executor getAsyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(40);
+        executor.setCorePoolSize(20);
         executor.setThreadNamePrefix("2024-Pium-Thread: ");
         executor.initialize();
         return executor;

--- a/backend/pium/src/main/java/com/official/pium/notification/fcm/application/FcmMessageSender.java
+++ b/backend/pium/src/main/java/com/official/pium/notification/fcm/application/FcmMessageSender.java
@@ -49,7 +49,7 @@ public class FcmMessageSender implements MessageSendManager {
                     .build();
 
             if (FirebaseApp.getApps().isEmpty()) {
-                FirebaseApp.initializeApp(options, "Pium");
+                FirebaseApp.initializeApp(options);
             }
         } catch (FileNotFoundException e) {
             log.error("파일을 찾을 수 없습니다. " + e);

--- a/backend/pium/src/main/java/com/official/pium/notification/fcm/application/FcmMessageSender.java
+++ b/backend/pium/src/main/java/com/official/pium/notification/fcm/application/FcmMessageSender.java
@@ -44,10 +44,12 @@ public class FcmMessageSender implements MessageSendManager {
         try {
             serviceAccount = new FileInputStream(JSON_FILE_PATH);
             FirebaseOptions options = FirebaseOptions.builder()
-                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
-                .build();
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
 
-            FirebaseApp.initializeApp(options);
+            if (FirebaseApp.getApps().isEmpty()) {
+                FirebaseApp.initializeApp(options, "Pium");
+            }
         } catch (FileNotFoundException e) {
             log.error("파일을 찾을 수 없습니다. " + e);
         } catch (IOException e) {
@@ -57,13 +59,13 @@ public class FcmMessageSender implements MessageSendManager {
 
     public void sendMessageTo(String targetToken, String title, String body) {
         Notification notification = Notification.builder()
-            .setTitle(title)
-            .setBody(body)
-            .build();
+                .setTitle(title)
+                .setBody(body)
+                .build();
         Message message = Message.builder()
-            .setToken(targetToken)
-            .setNotification(notification)
-            .build();
+                .setToken(targetToken)
+                .setNotification(notification)
+                .build();
         try {
             String response = FirebaseMessaging.getInstance().sendAsync(message).get();
             log.info("응답 결과 : " + response);
@@ -100,24 +102,24 @@ public class FcmMessageSender implements MessageSendManager {
 
     private FcmMessageResponse makeMessage(String targetToken, String title, String body) {
         return FcmMessageResponse.builder()
-            .message(FcmMessageResponse.Message.builder()
-                .token(targetToken)
-                .notification(FcmMessageResponse.Notification.builder()
-                    .title(title)
-                    .body(body)
-                    .image(null)
-                    .build()
+                .message(FcmMessageResponse.Message.builder()
+                        .token(targetToken)
+                        .notification(FcmMessageResponse.Notification.builder()
+                                .title(title)
+                                .body(body)
+                                .image(null)
+                                .build()
+                        )
+                        .build()
                 )
-                .build()
-            )
-            .validate_only(false)
-            .build();
+                .validate_only(false)
+                .build();
     }
 
     private String getAccessToken() throws IOException {
         GoogleCredentials googleCredentials = GoogleCredentials
-            .fromStream(new ClassPathResource(keyPath).getInputStream())
-            .createScoped(keyScope);
+                .fromStream(new ClassPathResource(keyPath).getInputStream())
+                .createScoped(keyScope);
         googleCredentials.refreshIfExpired();
         return googleCredentials.getAccessToken().getTokenValue();
     }

--- a/backend/pium/src/main/java/com/official/pium/notification/fcm/application/FcmMessageSender.java
+++ b/backend/pium/src/main/java/com/official/pium/notification/fcm/application/FcmMessageSender.java
@@ -25,7 +25,8 @@ import org.springframework.web.client.RestTemplate;
 @RequiredArgsConstructor
 public class FcmMessageSender implements MessageSendManager {
 
-    private static final String JSON_FILE_PATH = "src/main/resources/config/pium-fcm.json";
+    private static final String SYSTEM_PATH = System.getProperty("user.dir");
+    private static final String JSON_FILE_PATH = "/src/main/resources/config/pium-fcm.json";
 
     @Value("${fcm.api.url}")
     private String apiUrl;
@@ -42,7 +43,7 @@ public class FcmMessageSender implements MessageSendManager {
     public void initialize() {
         FileInputStream serviceAccount;
         try {
-            serviceAccount = new FileInputStream(JSON_FILE_PATH);
+            serviceAccount = new FileInputStream(SYSTEM_PATH + JSON_FILE_PATH);
             FirebaseOptions options = FirebaseOptions.builder()
                     .setCredentials(GoogleCredentials.fromStream(serviceAccount))
                     .build();

--- a/backend/pium/src/main/java/com/official/pium/notification/fcm/application/FcmMessageSender.java
+++ b/backend/pium/src/main/java/com/official/pium/notification/fcm/application/FcmMessageSender.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 
@@ -21,7 +22,8 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class FcmMessageSender implements MessageSendManager {
 
-    private static final String FCM_JSON_PATH = "config/pium-fcm.json";
+    @Value("${fcm.json.path}")
+    private String FCM_JSON_PATH;
 
     @PostConstruct
     public void initialize() {

--- a/backend/pium/src/main/java/com/official/pium/notification/fcm/application/FcmMessageSender.java
+++ b/backend/pium/src/main/java/com/official/pium/notification/fcm/application/FcmMessageSender.java
@@ -21,10 +21,12 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class FcmMessageSender implements MessageSendManager {
 
+    private static final String FCM_JSON_PATH = "config/pium-fcm.json";
+
     @PostConstruct
     public void initialize() {
         try {
-            ClassPathResource resource = new ClassPathResource("config/pium-fcm.json");
+            ClassPathResource resource = new ClassPathResource(FCM_JSON_PATH);
             FirebaseOptions options = FirebaseOptions.builder()
                     .setCredentials(GoogleCredentials.fromStream(resource.getInputStream()))
                     .build();

--- a/backend/pium/src/main/java/com/official/pium/notification/fcm/application/FcmMessageSender.java
+++ b/backend/pium/src/main/java/com/official/pium/notification/fcm/application/FcmMessageSender.java
@@ -7,54 +7,35 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
 import com.official.pium.notification.application.MessageSendManager;
-import com.official.pium.notification.fcm.dto.FcmMessageResponse;
 import jakarta.annotation.PostConstruct;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestTemplate;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class FcmMessageSender implements MessageSendManager {
 
-    private static final String SYSTEM_PATH = System.getProperty("user.dir");
-    private static final String JSON_FILE_PATH = "/src/main/resources/config/pium-fcm.json";
-
-    @Value("${fcm.api.url}")
-    private String apiUrl;
-
-    @Value("${fcm.key.path}")
-    private String keyPath;
-
-    @Value("${fcm.key.scope}")
-    private String keyScope;
-
-    private final RestTemplate restTemplate;
-
     @PostConstruct
     public void initialize() {
-        FileInputStream serviceAccount;
         try {
-            serviceAccount = new FileInputStream(SYSTEM_PATH + JSON_FILE_PATH);
+            ClassPathResource resource = new ClassPathResource("config/pium-fcm.json");
             FirebaseOptions options = FirebaseOptions.builder()
-                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .setCredentials(GoogleCredentials.fromStream(resource.getInputStream()))
                     .build();
 
             if (FirebaseApp.getApps().isEmpty()) {
                 FirebaseApp.initializeApp(options);
             }
         } catch (FileNotFoundException e) {
-            log.error("파일을 찾을 수 없습니다. " + e);
+            log.error("파일을 찾을 수 없습니다. ", e);
         } catch (IOException e) {
-            log.error("FCM 인증이 실패했습니다. " + e);
+            log.error("FCM 인증이 실패했습니다. ", e);
         }
     }
 
@@ -69,59 +50,11 @@ public class FcmMessageSender implements MessageSendManager {
                 .build();
         try {
             String response = FirebaseMessaging.getInstance().sendAsync(message).get();
-            log.info("응답 결과 : " + response);
+            log.info("알림 전송 성공 : " + response);
         } catch (InterruptedException e) {
-            log.error(e.getMessage());
+            log.error("FCM 알림 스레드에서 문제가 발생했습니다.", e);
         } catch (ExecutionException e) {
-            log.error(e.getMessage());
+            log.error("FCM 알림 전송에 실패했습니다.", e);
         }
-    }
-
-//    public void sendMessageTo(String targetToken, String title, String body) {
-//        try {
-//            FcmMessageResponse message = makeMessage(targetToken, title, body);
-//
-//            HttpHeaders headers = new HttpHeaders();
-//            headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + getAccessToken());
-//            headers.set(HttpHeaders.CONTENT_TYPE, "application/json; UTF-8");
-//
-//            HttpEntity<FcmMessageResponse> request = new HttpEntity<>(message, headers);
-//
-//            ResponseEntity<FcmMessageResponse> postResult = restTemplate.postForEntity(
-//                apiUrl,
-//                request,
-//                FcmMessageResponse.class
-//            );
-//
-//            log.info("FCM 메시지 전송 성공: {}", postResult.getBody());
-//
-//        } catch (Exception e) {
-//            log.error("FCM 메시지 전송 실패", e);
-//            throw new FcmException.FcmMessageSendException(e.getMessage());
-//        }
-//    }
-
-    private FcmMessageResponse makeMessage(String targetToken, String title, String body) {
-        return FcmMessageResponse.builder()
-                .message(FcmMessageResponse.Message.builder()
-                        .token(targetToken)
-                        .notification(FcmMessageResponse.Notification.builder()
-                                .title(title)
-                                .body(body)
-                                .image(null)
-                                .build()
-                        )
-                        .build()
-                )
-                .validate_only(false)
-                .build();
-    }
-
-    private String getAccessToken() throws IOException {
-        GoogleCredentials googleCredentials = GoogleCredentials
-                .fromStream(new ClassPathResource(keyPath).getInputStream())
-                .createScoped(keyScope);
-        googleCredentials.refreshIfExpired();
-        return googleCredentials.getAccessToken().getTokenValue();
     }
 }

--- a/backend/pium/src/main/java/com/official/pium/notification/fcm/application/FcmMessageSender.java
+++ b/backend/pium/src/main/java/com/official/pium/notification/fcm/application/FcmMessageSender.java
@@ -1,24 +1,31 @@
 package com.official.pium.notification.fcm.application;
 
 import com.google.auth.oauth2.GoogleCredentials;
-import com.official.pium.notification.fcm.dto.FcmMessageResponse;
-import com.official.pium.notification.fcm.exception.FcmException;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
 import com.official.pium.notification.application.MessageSendManager;
+import com.official.pium.notification.fcm.dto.FcmMessageResponse;
+import jakarta.annotation.PostConstruct;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
-import java.io.IOException;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class FcmMessageSender implements MessageSendManager {
+
+    private static final String JSON_FILE_PATH = "src/main/resources/config/pium-fcm.json";
 
     @Value("${fcm.api.url}")
     private String apiUrl;
@@ -31,50 +38,86 @@ public class FcmMessageSender implements MessageSendManager {
 
     private final RestTemplate restTemplate;
 
-    public void sendMessageTo(String targetToken, String title, String body) {
+    @PostConstruct
+    public void initialize() {
+        FileInputStream serviceAccount;
         try {
-            FcmMessageResponse message = makeMessage(targetToken, title, body);
+            serviceAccount = new FileInputStream(JSON_FILE_PATH);
+            FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                .build();
 
-            HttpHeaders headers = new HttpHeaders();
-            headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + getAccessToken());
-            headers.set(HttpHeaders.CONTENT_TYPE, "application/json; UTF-8");
-
-            HttpEntity<FcmMessageResponse> request = new HttpEntity<>(message, headers);
-
-            ResponseEntity<FcmMessageResponse> postResult = restTemplate.postForEntity(
-                    apiUrl,
-                    request,
-                    FcmMessageResponse.class
-            );
-
-            log.info("FCM 메시지 전송 성공: {}", postResult.getBody());
-
-        } catch (Exception e) {
-            log.error("FCM 메시지 전송 실패", e);
-            throw new FcmException.FcmMessageSendException(e.getMessage());
+            FirebaseApp.initializeApp(options);
+        } catch (FileNotFoundException e) {
+            log.error("파일을 찾을 수 없습니다. " + e);
+        } catch (IOException e) {
+            log.error("FCM 인증이 실패했습니다. " + e);
         }
     }
 
+    public void sendMessageTo(String targetToken, String title, String body) {
+        Notification notification = Notification.builder()
+            .setTitle(title)
+            .setBody(body)
+            .build();
+        Message message = Message.builder()
+            .setToken(targetToken)
+            .setNotification(notification)
+            .build();
+        try {
+            String response = FirebaseMessaging.getInstance().sendAsync(message).get();
+            log.info("응답 결과 : " + response);
+        } catch (InterruptedException e) {
+            log.error(e.getMessage());
+        } catch (ExecutionException e) {
+            log.error(e.getMessage());
+        }
+    }
+
+//    public void sendMessageTo(String targetToken, String title, String body) {
+//        try {
+//            FcmMessageResponse message = makeMessage(targetToken, title, body);
+//
+//            HttpHeaders headers = new HttpHeaders();
+//            headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + getAccessToken());
+//            headers.set(HttpHeaders.CONTENT_TYPE, "application/json; UTF-8");
+//
+//            HttpEntity<FcmMessageResponse> request = new HttpEntity<>(message, headers);
+//
+//            ResponseEntity<FcmMessageResponse> postResult = restTemplate.postForEntity(
+//                apiUrl,
+//                request,
+//                FcmMessageResponse.class
+//            );
+//
+//            log.info("FCM 메시지 전송 성공: {}", postResult.getBody());
+//
+//        } catch (Exception e) {
+//            log.error("FCM 메시지 전송 실패", e);
+//            throw new FcmException.FcmMessageSendException(e.getMessage());
+//        }
+//    }
+
     private FcmMessageResponse makeMessage(String targetToken, String title, String body) {
         return FcmMessageResponse.builder()
-                .message(FcmMessageResponse.Message.builder()
-                        .token(targetToken)
-                        .notification(FcmMessageResponse.Notification.builder()
-                                .title(title)
-                                .body(body)
-                                .image(null)
-                                .build()
-                        )
-                        .build()
+            .message(FcmMessageResponse.Message.builder()
+                .token(targetToken)
+                .notification(FcmMessageResponse.Notification.builder()
+                    .title(title)
+                    .body(body)
+                    .image(null)
+                    .build()
                 )
-                .validate_only(false)
-                .build();
+                .build()
+            )
+            .validate_only(false)
+            .build();
     }
 
     private String getAccessToken() throws IOException {
         GoogleCredentials googleCredentials = GoogleCredentials
-                .fromStream(new ClassPathResource(keyPath).getInputStream())
-                .createScoped(keyScope);
+            .fromStream(new ClassPathResource(keyPath).getInputStream())
+            .createScoped(keyScope);
         googleCredentials.refreshIfExpired();
         return googleCredentials.getAccessToken().getTokenValue();
     }

--- a/backend/pium/src/main/resources/application.yml
+++ b/backend/pium/src/main/resources/application.yml
@@ -27,11 +27,9 @@ management:
   endpoints:
     enabled-by-default: false
 fcm:
-  key:
-    path: test/
-    scope: https://www.googleapis.com/auth/firebase.messaging
-  api:
-    url: https://fcm.googleapis.com/v1/projects/project-id/messages:send
+  json:
+    path: config/pium-fcm.json
+
 petPlant:
   image:
     directory: test

--- a/backend/pium/src/test/resources/application.yml
+++ b/backend/pium/src/test/resources/application.yml
@@ -64,11 +64,8 @@ server:
     max-http-form-post-size: 10MB
 
 fcm:
-  key:
+  json:
     path: config/pium-fcm.json
-    scope: https://www.googleapis.com/auth/firebase.messaging
-  api:
-    url: https://fcm.googleapis.com/v1/projects/pium-test/messages:send
 
 management:
   endpoint:


### PR DESCRIPTION
 **※ 해당 PR 및 커밋은 이건회(@rawfishthelgh )와 함께 몹 프로그래밍으로 작성했습니다**

# 🔥 연관 이슈

- close #498 

# 🚀 작업 내용

FCM 서버에서 알림 처리를 하는 로직을 비동기로 처리할 수 있도록 변경했습니다.
기존에 사용하던 `Restemplate`을 제거하고 `FirebaseOptions` 객체를 이용해 서버 정보를 추가한 후 `FirebaseMessaging` 객체의 `sendAsync` 메서드를 통해 알림을 전송하게끔 구현했습니다.

```java
FirebaseMessaging.getInstance().sendAsync(message).get();
```
비동기 코드임에도 get을 호출해 response를 반환받은 이유는 비동기 처리 로직에서 future 타입의 결과를 받아 알림 요청의 성공 유무를 판단하기 위함입니다. 완전 비동기 호출보다 성능은 아~주 약간 떨어지지만 확실히 알림 전송 결과를 받아보는 것이 중요하기 때문에 위와 같이 결정했습니다.

곧 알림 실패 시 재전송하는 기능을 추가할 예정입니다 🥳

# 💬 리뷰 중점사항

이번에도 잘 부탁드립니다.